### PR TITLE
fix: stale ack detection incorrectly drops acks after channel restoration

### DIFF
--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
@@ -5,6 +5,8 @@ import dev.kourier.amqp.channel.*
 import dev.kourier.amqp.connection.ConnectionState
 import dev.kourier.amqp.states.*
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 open class RobustAMQPChannel(
     override val connection: RobustAMQPConnection,
@@ -18,6 +20,8 @@ open class RobustAMQPChannel(
     // Each restore increments deliveryTagOffset by the highest broker tag seen in that epoch,
     // making adjusted tags globally monotonically increasing across restores so that stale
     // acks can be detected even when the broker resets its delivery tag counter to 1.
+    // All three fields are guarded by deliveryTagMutex since delivery callbacks run concurrently.
+    private val deliveryTagMutex = Mutex()
     private var deliveryTagOffset: ULong = 0u
     private var deliveryTagOffsetBeforeRestore: ULong = 0u
     private var maxBrokerTagInCurrentEpoch: ULong = 0u
@@ -29,13 +33,6 @@ open class RobustAMQPChannel(
     private val boundQueues = mutableMapOf<Triple<String, String, String>, BoundQueue>()
     private val consumedQueues = mutableMapOf<Pair<String, String>, ConsumedQueue>()
 
-    private fun isStaleDeliveryTag(adjustedDeliveryTag: ULong): Boolean {
-        // Adjusted tags from before the last restoration are stale.
-        // deliveryTagOffsetBeforeRestore is the ceiling of all adjusted tags issued before the
-        // most recent restore, so any tag <= it was issued on an old channel.
-        return adjustedDeliveryTag <= deliveryTagOffsetBeforeRestore
-    }
-
     /**
      * Robust channels should not be removed from registry on broker close - they restore instead
      */
@@ -44,7 +41,9 @@ open class RobustAMQPChannel(
     @InternalAmqpApi
     fun prepareForRestore() {
         if (restoreCompleted.isCompleted) restoreCompleted = CompletableDeferred()
-        // Accumulate offset so adjusted tags never repeat across restores
+        // Accumulate offset so adjusted tags never repeat across restores.
+        // No need to lock here: prepareForRestore() is always called before the new channel is
+        // open, so no delivery callbacks can be racing at this point.
         deliveryTagOffset += maxBrokerTagInCurrentEpoch
         deliveryTagOffsetBeforeRestore = deliveryTagOffset
         maxBrokerTagInCurrentEpoch = 0u
@@ -221,6 +220,17 @@ open class RobustAMQPChannel(
         }
     }
 
+    override suspend fun basicGet(queue: String, noAck: Boolean): AMQPResponse.Channel.Message.Get {
+        val result = super.basicGet(queue, noAck)
+        val message = result.message ?: return result
+        val adjustedMessage = deliveryTagMutex.withLock {
+            val brokerTag = message.deliveryTag
+            if (brokerTag > maxBrokerTagInCurrentEpoch) maxBrokerTagInCurrentEpoch = brokerTag
+            message.copy(deliveryTag = brokerTag + deliveryTagOffset)
+        }
+        return result.copy(message = adjustedMessage)
+    }
+
     override suspend fun basicConsume(
         queue: String,
         consumerTag: String,
@@ -233,14 +243,14 @@ open class RobustAMQPChannel(
         return super.basicConsume(
             queue, consumerTag, noAck, exclusive, arguments,
             onDelivery = { delivery ->
-                val brokerTag = delivery.message.deliveryTag
-                if (brokerTag > maxBrokerTagInCurrentEpoch) maxBrokerTagInCurrentEpoch = brokerTag
-                // Adjust the delivery tag to be globally unique across restores.
-                // The broker resets its counter to 1 on each new channel, but consumers store the
-                // tag and use it later for basicAck — so we make it monotonically increasing here.
-                val adjustedDelivery = delivery.copy(
-                    message = delivery.message.copy(deliveryTag = brokerTag + deliveryTagOffset)
-                )
+                val adjustedDelivery = deliveryTagMutex.withLock {
+                    val brokerTag = delivery.message.deliveryTag
+                    if (brokerTag > maxBrokerTagInCurrentEpoch) maxBrokerTagInCurrentEpoch = brokerTag
+                    // Adjust the delivery tag to be globally unique across restores.
+                    // The broker resets its counter to 1 on each new channel, but consumers store the
+                    // tag and use it later for basicAck — so we make it monotonically increasing here.
+                    delivery.copy(message = delivery.message.copy(deliveryTag = brokerTag + deliveryTagOffset))
+                }
                 onDelivery(adjustedDelivery)
             },
             onCanceled = { response ->
@@ -270,29 +280,38 @@ open class RobustAMQPChannel(
     override suspend fun basicAck(deliveryTag: ULong, multiple: Boolean) {
         // Silently ignore acks for stale delivery tags (from before channel restoration)
         // This prevents PRECONDITION_FAILED errors when acking old messages
-        if (isStaleDeliveryTag(deliveryTag)) {
+        val (stale, brokerTag) = deliveryTagMutex.withLock {
+            Pair(deliveryTag <= deliveryTagOffsetBeforeRestore, deliveryTag - deliveryTagOffset)
+        }
+        if (stale) {
             logger.debug("Ignoring ack for stale delivery tag $deliveryTag (offset: $deliveryTagOffsetBeforeRestore)")
             return
         }
-        super.basicAck(deliveryTag - deliveryTagOffset, multiple)
+        super.basicAck(brokerTag, multiple)
     }
 
     override suspend fun basicNack(deliveryTag: ULong, multiple: Boolean, requeue: Boolean) {
         // Silently ignore nacks for stale delivery tags
-        if (isStaleDeliveryTag(deliveryTag)) {
+        val (stale, brokerTag) = deliveryTagMutex.withLock {
+            Pair(deliveryTag <= deliveryTagOffsetBeforeRestore, deliveryTag - deliveryTagOffset)
+        }
+        if (stale) {
             logger.debug("Ignoring nack for stale delivery tag $deliveryTag (offset: $deliveryTagOffsetBeforeRestore)")
             return
         }
-        super.basicNack(deliveryTag - deliveryTagOffset, multiple, requeue)
+        super.basicNack(brokerTag, multiple, requeue)
     }
 
     override suspend fun basicReject(deliveryTag: ULong, requeue: Boolean) {
         // Silently ignore rejects for stale delivery tags
-        if (isStaleDeliveryTag(deliveryTag)) {
+        val (stale, brokerTag) = deliveryTagMutex.withLock {
+            Pair(deliveryTag <= deliveryTagOffsetBeforeRestore, deliveryTag - deliveryTagOffset)
+        }
+        if (stale) {
             logger.debug("Ignoring reject for stale delivery tag $deliveryTag (offset: $deliveryTagOffsetBeforeRestore)")
             return
         }
-        super.basicReject(deliveryTag - deliveryTagOffset, requeue)
+        super.basicReject(brokerTag, requeue)
     }
 
 }

--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
@@ -14,9 +14,13 @@ open class RobustAMQPChannel(
 
     private var restoreCompleted = CompletableDeferred(Unit)
 
-    // Stale delivery tag tracking (similar to Java client's RecoveryAwareChannelN)
-    private var maxSeenDeliveryTag: ULong = 0u
+    // Adjusted delivery tag tracking (similar to Java client's RecoveryAwareChannelN):
+    // Each restore increments deliveryTagOffset by the highest broker tag seen in that epoch,
+    // making adjusted tags globally monotonically increasing across restores so that stale
+    // acks can be detected even when the broker resets its delivery tag counter to 1.
+    private var deliveryTagOffset: ULong = 0u
     private var deliveryTagOffsetBeforeRestore: ULong = 0u
+    private var maxBrokerTagInCurrentEpoch: ULong = 0u
 
     private var declaredQos: DeclaredQos? = null
     private val declaredExchanges = mutableMapOf<String, DeclaredExchange>()
@@ -25,13 +29,11 @@ open class RobustAMQPChannel(
     private val boundQueues = mutableMapOf<Triple<String, String, String>, BoundQueue>()
     private val consumedQueues = mutableMapOf<Pair<String, String>, ConsumedQueue>()
 
-    private fun trackDeliveryTag(deliveryTag: ULong) {
-        if (deliveryTag > maxSeenDeliveryTag) maxSeenDeliveryTag = deliveryTag
-    }
-
-    private fun isStaleDeliveryTag(deliveryTag: ULong): Boolean {
-        // Delivery tags from before the last restoration are stale
-        return deliveryTagOffsetBeforeRestore > 0u && deliveryTag <= deliveryTagOffsetBeforeRestore
+    private fun isStaleDeliveryTag(adjustedDeliveryTag: ULong): Boolean {
+        // Adjusted tags from before the last restoration are stale.
+        // deliveryTagOffsetBeforeRestore is the ceiling of all adjusted tags issued before the
+        // most recent restore, so any tag <= it was issued on an old channel.
+        return adjustedDeliveryTag <= deliveryTagOffsetBeforeRestore
     }
 
     /**
@@ -42,9 +44,10 @@ open class RobustAMQPChannel(
     @InternalAmqpApi
     fun prepareForRestore() {
         if (restoreCompleted.isCompleted) restoreCompleted = CompletableDeferred()
-        // Save the max delivery tag seen before restoration
-        // Any tags <= this value will be considered stale after restoration
-        deliveryTagOffsetBeforeRestore = maxSeenDeliveryTag
+        // Accumulate offset so adjusted tags never repeat across restores
+        deliveryTagOffset += maxBrokerTagInCurrentEpoch
+        deliveryTagOffsetBeforeRestore = deliveryTagOffset
+        maxBrokerTagInCurrentEpoch = 0u
         state = ConnectionState.CLOSED
     }
 
@@ -230,9 +233,15 @@ open class RobustAMQPChannel(
         return super.basicConsume(
             queue, consumerTag, noAck, exclusive, arguments,
             onDelivery = { delivery ->
-                // Track delivery tag to detect stale acks after restoration
-                trackDeliveryTag(delivery.message.deliveryTag)
-                onDelivery(delivery)
+                val brokerTag = delivery.message.deliveryTag
+                if (brokerTag > maxBrokerTagInCurrentEpoch) maxBrokerTagInCurrentEpoch = brokerTag
+                // Adjust the delivery tag to be globally unique across restores.
+                // The broker resets its counter to 1 on each new channel, but consumers store the
+                // tag and use it later for basicAck — so we make it monotonically increasing here.
+                val adjustedDelivery = delivery.copy(
+                    message = delivery.message.copy(deliveryTag = brokerTag + deliveryTagOffset)
+                )
+                onDelivery(adjustedDelivery)
             },
             onCanceled = { response ->
                 if (response is AMQPResponse.Channel.Closed && state == ConnectionState.OPEN) return@basicConsume
@@ -265,7 +274,7 @@ open class RobustAMQPChannel(
             logger.debug("Ignoring ack for stale delivery tag $deliveryTag (offset: $deliveryTagOffsetBeforeRestore)")
             return
         }
-        super.basicAck(deliveryTag, multiple)
+        super.basicAck(deliveryTag - deliveryTagOffset, multiple)
     }
 
     override suspend fun basicNack(deliveryTag: ULong, multiple: Boolean, requeue: Boolean) {
@@ -274,7 +283,7 @@ open class RobustAMQPChannel(
             logger.debug("Ignoring nack for stale delivery tag $deliveryTag (offset: $deliveryTagOffsetBeforeRestore)")
             return
         }
-        super.basicNack(deliveryTag, multiple, requeue)
+        super.basicNack(deliveryTag - deliveryTagOffset, multiple, requeue)
     }
 
     override suspend fun basicReject(deliveryTag: ULong, requeue: Boolean) {
@@ -283,7 +292,7 @@ open class RobustAMQPChannel(
             logger.debug("Ignoring reject for stale delivery tag $deliveryTag (offset: $deliveryTagOffsetBeforeRestore)")
             return
         }
-        super.basicReject(deliveryTag, requeue)
+        super.basicReject(deliveryTag - deliveryTagOffset, requeue)
     }
 
 }

--- a/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/RobustAMQPChannelTest.kt
+++ b/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/RobustAMQPChannelTest.kt
@@ -8,6 +8,7 @@ import io.ktor.utils.io.core.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.first
 import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.Uuid
 
@@ -332,8 +333,9 @@ class RobustAMQPChannelTest {
             closeEvent.await()
             reopenEvent.await()
 
-            // Try to ack the old message - this should be silently ignored (stale delivery tag)
-            // The robust client now tracks delivery tags and ignores acks for tags from before restoration
+            // Try to ack the old message - this should be silently ignored (stale delivery tag).
+            // The robust client adjusts delivery tags to be globally increasing across restores, so
+            // any tag <= deliveryTagOffsetBeforeRestore is from an old channel and safely discarded.
             channel.basicAck(delivery.message.deliveryTag)
 
             // Verify the channel is functional after recovery by publishing and consuming a new message
@@ -347,6 +349,85 @@ class RobustAMQPChannelTest {
 
             channel.close()
             assertTrue(receivedMessages.isClosedForReceive)
+        }
+    }
+
+    /**
+     * Regression test for: after channel restoration the broker resets its delivery tag counter to 1,
+     * so a new delivery can have the same numeric tag as a pre-restore delivery.  The robust client
+     * must still be able to ack the new delivery (and must silently drop the old one).
+     *
+     * Previous bug: isStaleDeliveryTag used a plain `tag <= offsetBeforeRestore` numeric comparison,
+     * which falsely treated post-restore tag 1 as stale when offsetBeforeRestore was also 1.
+     *
+     * Fix: delivery tags are adjusted to be globally monotonically increasing across restores
+     * (adjusted = brokerTag + deliveryTagOffset), so tags never repeat from the consumer's perspective.
+     */
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testAckAfterRestoreWithRepeatingDeliveryTag() = runBlocking {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val reopenEvent = async { channel.openedResponses.first() }
+
+            val queueName = "test-repeating-tag-queue-${Uuid.random()}"
+            val exchangeName = "test-repeating-tag-exchange-${Uuid.random()}"
+            val routingKey = "test.repeating"
+
+            channel.exchangeDeclare(exchangeName, BuiltinExchangeType.DIRECT, durable = false, arguments = emptyMap())
+            channel.queueDeclare(
+                queueName,
+                durable = false,
+                exclusive = false,
+                autoDelete = true,
+                arguments = mapOf("x-consumer-timeout" to Field.Long(1000)) // 1 second timeout
+            )
+            channel.queueBind(queueName, exchangeName, routingKey, arguments = emptyMap())
+
+            val receivedMessages = channel.basicConsume(
+                queue = queueName,
+                consumerTag = "repeating-tag-consumer",
+                noAck = false,
+                exclusive = false,
+                arguments = emptyMap()
+            )
+
+            // Publish and receive first message (broker assigns delivery tag 1)
+            channel.basicPublish("first".toByteArray(), exchangeName, routingKey)
+            val delivery1 = withTimeout(5.seconds) { receivedMessages.receive() }
+            assertEquals("first", delivery1.message.body.decodeToString())
+
+            // Let the consumer timeout expire without acking — channel gets closed and restored
+            delay(2000)
+            reopenEvent.await()
+
+            // Publish and receive second message (broker resets and assigns delivery tag 1 again on
+            // the new channel, but the robust client adjusts it to be higher than delivery1's tag)
+            channel.basicPublish("second".toByteArray(), exchangeName, routingKey)
+            val delivery2 = withTimeout(5.seconds) { receivedMessages.receive() }
+            assertEquals("second", delivery2.message.body.decodeToString())
+
+            // Adjusted tags must be monotonically increasing: delivery2 must have a higher tag
+            assertTrue(
+                delivery2.message.deliveryTag > delivery1.message.deliveryTag,
+                "Expected delivery2 tag (${delivery2.message.deliveryTag}) > delivery1 tag (${delivery1.message.deliveryTag}) after restore"
+            )
+
+            // Silently discard the stale ack (must not throw or close the channel)
+            channel.basicAck(delivery1.message.deliveryTag)
+
+            // Ack the new delivery — this must reach the broker (not be silently dropped).
+            // If incorrectly treated as stale the broker would redeliver "second" after the timeout.
+            channel.basicAck(delivery2.message.deliveryTag)
+
+            // Verify no redelivery occurs: the channel must stay open and no third message arrives
+            val redelivery = withTimeoutOrNull(2500.milliseconds) { receivedMessages.receive() }
+            assertNull(
+                redelivery,
+                "Expected no redelivery after successful ack, but got: ${redelivery?.message?.body?.decodeToString()}"
+            )
+
+            channel.close()
         }
     }
 


### PR DESCRIPTION
### Problem

After a channel is restored (e.g. due to consumer timeout), the broker resets its delivery tag counter to 1 on the new channel. The previous stale-ack detection used a numeric threshold: `deliveryTag <= deliveryTagOffsetBeforeRestore`. If the last delivery tag before restore was `N`, any post-restore delivery with tag `1..N` was falsely treated as stale and its ack silently dropped.

In practice this caused the consumer to appear active in the RabbitMQ management UI (the channel was correctly restored) but messages were never acknowledged — resulting in redelivery every 30 minutes (consumer timeout) indefinitely.

### Fix

Adopt the same approach as the Java RabbitMQ client: adjust delivery tags to be **globally monotonically increasing** across restores.

- A `deliveryTagOffset` accumulates the max broker tag from each completed epoch
- The `onDelivery` wrapper adjusts tags before passing them to consumers: `adjusted = brokerTag + deliveryTagOffset`
- On restore: `deliveryTagOffset += maxBrokerTagInCurrentEpoch`
- Stale check: `adjustedTag <= deliveryTagOffsetBeforeRestore` — unambiguous since adjusted tags never repeat across restores
- `basicAck/basicNack/basicReject` unadjust before sending to broker: `brokerTag = adjustedTag - deliveryTagOffset`

This works for both the callback-based consumer pattern and the `AMQPReceiveChannel` pattern (where acks are called outside the delivery callback).

### Test

Added `testAckAfterRestoreWithRepeatingDeliveryTag` which:
- Verifies that the adjusted delivery tag after restore is strictly greater than before (no tag reuse from the consumer's perspective)
- Verifies the ack actually reaches the broker by asserting no redelivery occurs within the consumer timeout window
