### PR TITLE
fix: don't swallow CancellationException in consumer/read-loop catches

### DIFF
--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
@@ -4,6 +4,7 @@ import dev.kourier.amqp.*
 import dev.kourier.amqp.channel.*
 import dev.kourier.amqp.connection.ConnectionState
 import dev.kourier.amqp.states.*
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.sync.Mutex
@@ -117,6 +118,14 @@ open class RobustAMQPChannel(
             // Throw a regular Exception (not CancellationException) so connectionFactory()
             // logs and iterates rather than cancelling the recovery coroutine.
             throw timeoutException
+        } catch (e: CancellationException) {
+            // Genuine cancellation (e.g. the connection was torn down, or cancelAll()
+            // cancelled brokerCloseRestoresScope mid-restore) — distinct from the
+            // TimeoutCancellationException case above. Unblock awaiting writers, then rethrow:
+            // cooperative cancellation must propagate, never be swallowed. Handled explicitly
+            // (rather than relying on the generic catch below) so this intent survives edits.
+            restoreCompleted.completeExceptionally(e)
+            throw e
         } catch (e: Exception) {
             restoreCompleted.completeExceptionally(e)
             throw e

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
@@ -307,7 +307,11 @@ open class DefaultAMQPChannel(
         val deferredListeningJob = CompletableDeferred<Job>()
         val listeningJob = connection.messageListeningScope.launch {
             channelResponses.collect { response ->
-                runCatching { // Catch to avoid cancelling messageListeningScope
+                // Catch to avoid cancelling messageListeningScope on a user-callback failure,
+                // but rethrow CancellationException so this job's own cancellation propagates
+                // (deferredListeningJob.cancel() below, and cancelAll() joining this job, both
+                // rely on cancellation actually stopping the collector).
+                try {
                     val consumerTag = deferredConsumerTag.await()
                     when (response) {
                         is AMQPResponse.Channel.Closed -> {
@@ -323,21 +327,25 @@ open class DefaultAMQPChannel(
                         }
 
                         is AMQPResponse.Channel.Message.Delivery -> if (response.consumerTag == consumerTag) launch {
-                            runCatching {
+                            try {
                                 logger.debug("Consumer $consumerTag on channel $id received delivery ${response.message.deliveryTag}")
                                 onDelivery(response)
-                            }.onFailure { exception ->
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Throwable) {
                                 logger.error(
                                     "Error processing delivery ${response.message.deliveryTag} on channel $id",
-                                    exception
+                                    e
                                 )
                             }
                         }
 
                         else -> {} // Ignore other responses
                     }
-                }.onFailure { exception ->
-                    logger.error("Error in consumer $consumerTag on channel $id", exception)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    logger.error("Error in consumer $consumerTag on channel $id", e)
                 }
             }
         }

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
@@ -160,6 +160,10 @@ open class DefaultAMQPConnection(
                     logger.debug("Received AMQP frame: $frame")
                     read(frame)
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                // Normal shutdown cancels socketSubscription; let it propagate rather than
+                // routing it through the broker/IO-failure close path.
+                throw e
             } catch (e: Exception) {
                 closeFromChannelException(e)
             }


### PR DESCRIPTION
## Summary

`runCatching` catches `Throwable` (including `CancellationException`), and a bare `catch (Exception)` catches it too — so cooperative cancellation was being silently absorbed and logged as an error instead of propagating. Three sites were affected:

- **`DefaultAMQPChannel` consumer listener** (`runCatching` around the collector body): the collector self-cancels its own listening job on `Channel.Closed` / `Basic.Canceled` *before* running `onCanceled`, and `cancelAll()` joins this job — both rely on cancellation actually stopping the collector. Swallowing it meant the cancellation was logged as `"Error in consumer ..."` instead.
- **`DefaultAMQPChannel` per-delivery `launch`** (`runCatching` around `onDelivery`): scope cancellation on connection close was logged as a spurious `"Error processing delivery ..."`.
- **`DefaultAMQPConnection` read loop** (`catch (Exception)` around `decodeStreaming`): normal shutdown cancellation of `socketSubscription` was routed through `closeFromChannelException` as if it were a broker/IO failure.

The broad catches are replaced with `try/catch` that rethrows `CancellationException` first, then handles real errors. `RobustAMQPChannel.restore()` already rethrew cancellation via its generic `catch (Exception)`, but an explicit `catch (CancellationException)` clause is added there too so the intent is documented and survives future edits.

No behavior change for genuine user-callback errors — those are still caught and logged exactly as before.

## Test plan

- [x] `./gradlew compileKotlinJvm compileTestKotlinJvm`
- [x] `./gradlew :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)