### PR TITLE
fix: consumer onCanceled ordering + non-blocking awaitClose cancel

### DIFF
--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
@@ -275,16 +275,28 @@ open class DefaultAMQPChannel(
             )
             deferredConsumeOk.complete(consumeOk)
             awaitClose {
-                runBlocking {
-                    if (state != ConnectionState.OPEN) return@runBlocking
-                    val cancel = Frame(
-                        channelId = id,
-                        payload = Frame.Method.Basic.Cancel(
-                            consumerTag = consumeOk.consumerTag,
-                            noWait = true
+                // awaitClose's block is not a suspend context. The previous code used
+                // runBlocking to call the suspending write(), which blocks the calling thread
+                // — it can deadlock when the receive channel is closed on a small dispatcher
+                // pool, and is unsupported on Kotlin/JS entirely. Send the Basic.Cancel as a
+                // fire-and-forget launch on the connection scope instead, gated on the channel
+                // still being open (the broker drops consumers automatically on channel close).
+                connection.messageListeningScope.launch {
+                    try {
+                        if (state != ConnectionState.OPEN) return@launch
+                        val cancel = Frame(
+                            channelId = id,
+                            payload = Frame.Method.Basic.Cancel(
+                                consumerTag = consumeOk.consumerTag,
+                                noWait = true
+                            )
                         )
-                    )
-                    write(cancel)
+                        write(cancel)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.debug("Failed to send Basic.Cancel for consumer ${consumeOk.consumerTag} on channel $id: ${e.message}")
+                    }
                 }
             }
         }
@@ -315,15 +327,20 @@ open class DefaultAMQPChannel(
                     val consumerTag = deferredConsumerTag.await()
                     when (response) {
                         is AMQPResponse.Channel.Closed -> {
-                            deferredListeningJob.await().cancel()
                             logger.debug("Consumer $consumerTag on channel $id canceled due to channel closed")
+                            // Run the user's onCanceled BEFORE cancelling our own job. Cancelling
+                            // first puts this coroutine into the cancelling state, so the suspending
+                            // onCanceled would throw at its first suspension point and the user's
+                            // cleanup (closing a session, completing a deferred, closing the produce
+                            // channel) would silently not run.
                             onCanceled(response)
+                            deferredListeningJob.await().cancel()
                         }
 
                         is AMQPResponse.Channel.Basic.Canceled -> if (response.consumerTag == consumerTag) {
-                            deferredListeningJob.await().cancel()
                             logger.debug("Consumer $consumerTag on channel $id canceled")
                             onCanceled(response)
+                            deferredListeningJob.await().cancel()
                         }
 
                         is AMQPResponse.Channel.Message.Delivery -> if (response.consumerTag == consumerTag) launch {

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/AMQPChannelTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/AMQPChannelTest.kt
@@ -1039,4 +1039,100 @@ class AMQPChannelTest {
         }
     }
 
+    // ISSUE-7: the consumer listener used to cancel its own listening job BEFORE invoking
+    // onCanceled. Since onCanceled runs inside that job, cancelling first put the coroutine
+    // into the cancelling state, so any suspension inside onCanceled threw CancellationException
+    // and the user's cleanup silently did not run. onCanceled must complete first.
+    @Test
+    fun testOnCanceledCompletesBeforeBasicCancelReturns() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val queueName = "test-oncanceled-cancel-${Uuid.random()}"
+            channel.queueDeclare {
+                name = queueName
+                durable = false
+                exclusive = true
+            }
+            try {
+                // onCanceled suspends (delay) before recording completion. basicCancel joins the
+                // listener, so by the time it returns the user's onCanceled must have finished.
+                val cleanupDone = CompletableDeferred<Unit>()
+                val consumeOk = channel.basicConsume(
+                    queue = queueName,
+                    onDelivery = { },
+                    onCanceled = {
+                        delay(50)
+                        cleanupDone.complete(Unit)
+                    }
+                )
+                channel.basicCancel(consumeOk.consumerTag)
+                assertTrue(
+                    cleanupDone.isCompleted,
+                    "onCanceled must run to completion before basicCancel returns"
+                )
+            } finally {
+                runCatching { channel.close() }
+            }
+        }
+    }
+
+    // ISSUE-7 (channel-close path): the same ordering bug applied to the listener's
+    // Channel.Closed branch. close() joins the listener (NEW-13), so a suspending onCanceled
+    // must run to completion before close() returns.
+    @Test
+    fun testOnCanceledCompletesOnChannelClose() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val queueName = "test-oncanceled-close-${Uuid.random()}"
+            channel.queueDeclare {
+                name = queueName
+                durable = false
+                exclusive = true
+            }
+            val cleanupDone = CompletableDeferred<Unit>()
+            channel.basicConsume(
+                queue = queueName,
+                onDelivery = { },
+                onCanceled = {
+                    delay(50)
+                    cleanupDone.complete(Unit)
+                }
+            )
+            channel.close()
+            assertTrue(
+                cleanupDone.isCompleted,
+                "onCanceled must run to completion before channel.close() returns"
+            )
+        }
+    }
+
+    // ISSUE-1: cancelling the receive channel triggers awaitClose, which must send Basic.Cancel
+    // without blocking the calling thread (the old code used runBlocking, which can deadlock on
+    // constrained dispatchers and is unsupported on JS). Polling the broker until the consumer
+    // disappears proves the cancel was actually sent; the bounded withTimeout fails fast on a hang.
+    @Test
+    fun testReceiveChannelCancelSendsBasicCancel() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            val queueName = "test-receive-cancel-${Uuid.random()}"
+            channel.queueDeclare {
+                name = queueName
+                durable = false
+                exclusive = true
+            }
+            try {
+                val deliveryChannel = channel.basicConsume(queue = queueName, noAck = true)
+                assertEquals(1u, channel.consumerCount(queueName))
+
+                deliveryChannel.cancel()
+                withTimeout(5000) {
+                    while (channel.consumerCount(queueName) != 0u) delay(20)
+                }
+                assertEquals(0u, channel.consumerCount(queueName))
+            } finally {
+                runCatching { channel.close() }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

Two consumer-lifecycle correctness bugs in `DefaultAMQPChannel.basicConsume`:

- **ISSUE-7 — `onCanceled` ran under cancellation.** The listener cancelled its own listening job *before* invoking `onCanceled`. Because `onCanceled` runs inside that job, cancelling first put the coroutine into the cancelling state, so a suspending `onCanceled` threw `CancellationException` at its first suspension point and the user's cleanup (closing a session, completing a deferred, closing the produce channel) silently did not run. This was masked until cancellation actually propagated (#58). Fix: invoke `onCanceled(response)` first, then cancel the job — in both the `Channel.Closed` and `Basic.Canceled` branches.

- **ISSUE-1 — blocking cancel in `awaitClose`.** The convenience `basicConsume` overload used `runBlocking` to send `Basic.Cancel` from its `awaitClose` block. `runBlocking` blocks the calling thread, which can deadlock when the receive channel is closed on a small dispatcher pool, and is unsupported on Kotlin/JS. Fix: send the cancel as a fire-and-forget `launch` on the connection scope, state-gated and wrapped to rethrow cancellation / log other failures.

No change to ack/nack behavior — the library does not make delivery-disposition decisions.

## Tests

- `testOnCanceledCompletesBeforeBasicCancelReturns` and `testOnCanceledCompletesOnChannelClose` cover ISSUE-7 — verified **failing** against the unfixed code and **passing** after the fix.
- `testReceiveChannelCancelSendsBasicCancel` guards ISSUE-1 by asserting the broker-side consumer is cancelled within a bounded timeout. Note: the `runBlocking` deadlock is dispatcher/JS-specific and does not reproduce deterministically on the JVM harness, so this is a behavioral guard rather than a red→green proof.

## Test plan

- [x] `./gradlew :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green, incl. existing `testConsumerErrorHandling`)