### PR TITLE
feat: detect missed server heartbeats; handle negotiated heartbeat=0

### DIFF
--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPConnection.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPConnection.kt
@@ -162,12 +162,14 @@ open class RobustAMQPConnection(
         socket?.close()
         socket = null
 
-        // The heartbeat job ticks against the now-dead socket until super.connect() restarts.
-        // Cancel it so it doesn't leak; startListening() relaunches it on reconnect.
-        // Do NOT cancel socketSubscription: the read loop is already exiting via the catch
-        // that brought us here.
+        // The heartbeat sender + watchdog tick against the now-dead socket until reconnect.
+        // Cancel them so they don't leak; startHeartbeat() (called from the Tune handler on
+        // reconnect) relaunches them. Do NOT cancel socketSubscription: the read loop is
+        // already exiting via the catch that brought us here.
         heartbeatSubscription?.cancel()
         heartbeatSubscription = null
+        heartbeatWatchdogSubscription?.cancel()
+        heartbeatWatchdogSubscription = null
 
         // Wake up any per-channel writers blocked on writeAndWaitForResponse{...}.first().
         // Without this, mid-flight calls (channel.open(), exchangeDeclare(), basicQos(), ...)

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
@@ -20,6 +20,7 @@ import kotlinx.io.IOException
 import kotlinx.serialization.encodeToByteArray
 import kotlin.concurrent.Volatile
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 open class DefaultAMQPConnection(
     override val config: AMQPConfig,
@@ -59,6 +60,17 @@ open class DefaultAMQPConnection(
 
     protected var socketSubscription: Job? = null
     protected var heartbeatSubscription: Job? = null
+
+    // Watchdog that detects missed *server* heartbeats. AMQP 0.9.1: if no frame (heartbeat or
+    // otherwise) is received for 2 * heartbeat, the peer is considered dead. Without this, a
+    // silently-vanished broker (cable pulled, NAT timeout, kernel panic) leaves the read loop
+    // blocked on readAvailable() forever and the robust connection never reconnects.
+    protected var heartbeatWatchdogSubscription: Job? = null
+
+    // Monotonic timestamp of the last frame received from the broker; updated by the read loop
+    // and read by the watchdog. @Volatile for cross-coroutine visibility (same pattern as state).
+    @Volatile
+    private var lastFrameReceivedAt = TimeSource.Monotonic.markNow()
 
     private val writeMutex = Mutex()
 
@@ -153,10 +165,16 @@ open class DefaultAMQPConnection(
     protected open fun startListening() {
         socketSubscription?.cancel()
         heartbeatSubscription?.cancel()
+        heartbeatWatchdogSubscription?.cancel()
+        // The heartbeat sender + watchdog are (re)started from the Tune handler once the broker's
+        // heartbeat interval is negotiated — they can't run here because the interval is unknown
+        // until Tune, and a negotiated 0 means heart-beating is disabled (no sender, no watchdog).
         socketSubscription = messageListeningScope.launch {
             val readChannel = this@DefaultAMQPConnection.readChannel ?: return@launch
             try {
                 FrameDecoder.decodeStreaming(readChannel) { frame ->
+                    // Any received frame (including heartbeats) resets the missed-heartbeat clock.
+                    lastFrameReceivedAt = TimeSource.Monotonic.markNow()
                     logger.debug("Received AMQP frame: $frame")
                     read(frame)
                 }
@@ -168,17 +186,49 @@ open class DefaultAMQPConnection(
                 closeFromChannelException(e)
             }
         }
+    }
+
+    /**
+     * (Re)starts the heartbeat sender and the missed-heartbeat watchdog using the broker-negotiated
+     * interval. Called from the [Frame.Method.Connection.Tune] handler. A negotiated value of 0
+     * disables heart-beating entirely (per AMQP 0.9.1) — neither job is started, which avoids both
+     * a `delay(0)` busy-spin in the sender and a watchdog whose `2 * 0 = 0` timeout would treat the
+     * connection as instantly dead.
+     */
+    protected open fun startHeartbeat(negotiatedHeartbeat: UShort) {
+        heartbeatSubscription?.cancel()
+        heartbeatWatchdogSubscription?.cancel()
+        if (negotiatedHeartbeat.toUInt() == 0u) {
+            logger.debug("Heartbeat disabled (negotiated 0); skipping heartbeat sender and watchdog")
+            return
+        }
+        val interval = negotiatedHeartbeat.toInt().seconds
+        // Reset the clock so the gap before the connection became OPEN isn't counted as silence.
+        lastFrameReceivedAt = TimeSource.Monotonic.markNow()
         heartbeatSubscription = messageListeningScope.launch {
             while (isActive) {
-                delay(heartbeat.toInt().seconds.inWholeMilliseconds / 2)
+                delay(interval / 2)
                 // Skip the periodic heartbeat once the connection has begun shutting down.
                 // close() cancels this job before sending Connection.Close, but a tick that has
                 // already passed `delay` would otherwise still call sendHeartbeat() and push a
                 // frame onto the wire after Close — the broker treats that as `unexpected_frame:
                 // "type 8"`, floods its logs, and can spike latency for unrelated in-flight ops.
-                // The state check here keeps the public sendHeartbeat() API throw-on-closed.
                 if (state != ConnectionState.OPEN) continue
                 sendHeartbeat()
+            }
+        }
+        val timeout = interval * 2
+        heartbeatWatchdogSubscription = messageListeningScope.launch {
+            while (isActive) {
+                delay(interval / 2)
+                if (state != ConnectionState.OPEN) continue
+                if (lastFrameReceivedAt.elapsedNow() > timeout) {
+                    logger.debug("No frame received for >${timeout}; treating connection as dead")
+                    closeFromChannelException(
+                        IOException("Missed server heartbeats (interval = ${negotiatedHeartbeat}s)")
+                    )
+                    return@launch
+                }
             }
         }
     }
@@ -243,6 +293,8 @@ open class DefaultAMQPConnection(
                 )
                 write(tuneOk)
                 write(open)
+                // Start (or restart, on reconnect) heart-beating now that the interval is known.
+                startHeartbeat(payload.heartbeat)
             }
 
             is Frame.Method.Connection.TuneOk -> error("Unexpected TuneOk frame received: $payload")
@@ -577,6 +629,8 @@ open class DefaultAMQPConnection(
         // would still slip onto the wire after Close.
         heartbeatSubscription?.cancelAndJoin()
         heartbeatSubscription = null
+        heartbeatWatchdogSubscription?.cancel()
+        heartbeatWatchdogSubscription = null
         val close = Frame(
             channelId = 0u,
             payload = Frame.Method.Connection.Close(
@@ -602,6 +656,7 @@ open class DefaultAMQPConnection(
 
         socketSubscription?.cancel()
         heartbeatSubscription?.cancel()
+        heartbeatWatchdogSubscription?.cancel()
         socket?.close()
         readChannel?.cancel()
         writeChannel?.cancel(IOException())
@@ -614,6 +669,7 @@ open class DefaultAMQPConnection(
 
         socketSubscription = null
         heartbeatSubscription = null
+        heartbeatWatchdogSubscription = null
         socket = null
         readChannel = null
         writeChannel = null

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/AMQPConnectionTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/AMQPConnectionTest.kt
@@ -7,9 +7,11 @@ import io.ktor.http.*
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlin.test.*
 
 class AMQPConnectionTest {
@@ -97,6 +99,69 @@ class AMQPConnectionTest {
             } finally {
                 connection.close()
                 fakeServer.serverJob.cancel()
+            }
+        }
+    }
+
+    // NEW-2: the broker advertises a 1s heartbeat then goes silent. Per AMQP 0.9.1 the client
+    // must treat the connection as dead after 2 * heartbeat with no frame received, so
+    // connectionClosed completes (which is what drives robust reconnect). Without the watchdog
+    // the read loop blocks on readAvailable() forever and this never completes.
+    @Test
+    fun testMissedServerHeartbeatsClosesConnection() = runTest {
+        withContext(Dispatchers.Default) {
+            val fakeServer = FakeServer(
+                this,
+                heartbeat = 1u,
+                behavior = FakeServer.Behavior.StaySilent,
+                port = 5674,
+            )
+            fakeServer.serverReady.await()
+            val connection = createAMQPConnection(this) {
+                server { port = 5674 }
+            }
+            try {
+                val closed = withTimeout(8000) { connection.connectionClosed.await() }
+                assertTrue(
+                    closed.replyText?.contains("heartbeat", ignoreCase = true) == true,
+                    "expected a missed-heartbeat close, got: ${closed.replyText}"
+                )
+            } finally {
+                connection.close()
+                fakeServer.serverJob.cancel()
+            }
+        }
+    }
+
+    // NEW-11: a negotiated heartbeat of 0 disables heart-beating. The client must NOT start the
+    // watchdog (a 2 * 0 = 0s timeout would mark the connection dead instantly) nor a delay(0)
+    // busy-spin sender. The connection must stay open.
+    @Test
+    fun testZeroHeartbeatDisablesWatchdog() = runTest {
+        withContext(Dispatchers.Default) {
+            val fakeServer = FakeServer(
+                this,
+                heartbeat = 0u,
+                behavior = FakeServer.Behavior.StaySilent,
+                port = 5675,
+            )
+            fakeServer.serverReady.await()
+            val connection = createAMQPConnection(this) {
+                server { port = 5675 }
+            }
+            try {
+                // Give a wrongly-started watchdog ample time to misfire.
+                delay(3000)
+                assertFalse(
+                    connection.connectionClosed.isCompleted,
+                    "connection must stay open when heartbeat is disabled (0)"
+                )
+            } finally {
+                // The silent server never answers Connection.Close, so a graceful close() would
+                // block on CloseOk. Drop the server socket first (tears down the client read loop)
+                // and time-box the close as a safety net.
+                fakeServer.serverJob.cancel()
+                runCatching { withTimeout(2000) { connection.close() } }
             }
         }
     }

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/FakeServer.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/FakeServer.kt
@@ -8,14 +8,37 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.encodeToByteArray
 
-class FakeServer(coroutineScope: CoroutineScope) {
+/**
+ * Minimal fake AMQP server for connection-level tests. Completes a stripped-down handshake
+ * (skips Connection.Start: reads the client's protocol header, replies Tune then OpenOk), then
+ * behaves according to [behavior].
+ *
+ * @param heartbeat the heartbeat interval (seconds) advertised in the Tune frame; the client
+ *   echoes it in TuneOk, so this drives the negotiated value.
+ * @param behavior what to do after the handshake.
+ * @param port the TCP port to bind (use distinct ports across tests to avoid rebind races).
+ */
+class FakeServer(
+    coroutineScope: CoroutineScope,
+    heartbeat: UShort = 60u,
+    behavior: Behavior = Behavior.CloseAbruptly,
+    port: Int = 5673,
+) {
+
+    enum class Behavior {
+        /** Close the socket abruptly shortly after the handshake. */
+        CloseAbruptly,
+
+        /** Keep the socket open but send no further frames — exercises missed-heartbeat detection. */
+        StaySilent,
+    }
 
     val serverReady = CompletableDeferred<Unit>()
     val serverClosed = CompletableDeferred<Unit>()
 
     val serverJob = coroutineScope.launch {
         val selectorManager = SelectorManager(Dispatchers.IO)
-        val server = aSocket(selectorManager).tcp().bind("127.0.0.1", 5673)
+        val server = aSocket(selectorManager).tcp().bind("127.0.0.1", port)
         serverReady.complete(Unit)
         val clientSocket = server.accept()
 
@@ -30,7 +53,7 @@ class FakeServer(coroutineScope: CoroutineScope) {
                     payload = Frame.Method.Connection.Tune(
                         channelMax = 1u,
                         frameMax = 4096u,
-                        heartbeat = 60u,
+                        heartbeat = heartbeat,
                     )
                 )
             )
@@ -47,11 +70,30 @@ class FakeServer(coroutineScope: CoroutineScope) {
             )
         )
 
-        delay(100)
-        clientSocket.close() // Simulate server closing connection abruptly
-        server.close()
-        delay(100)
-        serverClosed.complete(Unit)
+        when (behavior) {
+            Behavior.CloseAbruptly -> {
+                delay(100)
+                clientSocket.close() // Simulate server closing connection abruptly
+                server.close()
+                delay(100)
+                serverClosed.complete(Unit)
+            }
+
+            Behavior.StaySilent -> {
+                // Send nothing further. Drain whatever the client writes (e.g. its own heartbeats)
+                // so its write buffer can't fill, until the client disconnects or we're cancelled.
+                try {
+                    val buffer = ByteArray(1024)
+                    while (isActive) {
+                        if (readChannel.readAvailable(buffer) == -1) break
+                    }
+                } finally {
+                    clientSocket.close()
+                    server.close()
+                    serverClosed.complete(Unit)
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

- **NEW-2 — missed server heartbeat detection.** kourier sent heartbeats but never checked whether the broker was still sending them. If the broker host vanished silently (cable pulled, NAT timeout, kernel panic), the read loop blocked on `readAvailable()` forever and `RobustAMQPConnection` never reconnected (TCP keepalive — ~2h on Linux — was the only fallback). The read loop now stamps a monotonic `lastFrameReceivedAt` on every received frame, and a watchdog polls every `heartbeat/2`; if no frame has arrived for `2 * heartbeat` (per AMQP 0.9.1) it calls `closeFromChannelException(...)`, which drives robust reconnect.

- **NEW-11 — negotiated `heartbeat = 0`.** The sender was launched in `startListening()` before `Tune`, using the default interval, and a negotiated `heartbeat = 0` made it busy-spin on `delay(0)`. The sender and watchdog now start from the `Connection.Tune` handler via `startHeartbeat(negotiatedHeartbeat)`, with the interval snapshotted into the launched coroutines. A negotiated `0` disables heart-beating entirely (no sender, no watchdog), per the spec.

The watchdog is cancelled in `close()`, `cancelAll()`, and robust `closeFromBroker()`.

## Tests

`FakeServer`-backed (no broker needed):
- `testMissedServerHeartbeatsClosesConnection` — silent server advertising a 1s heartbeat; the connection closes within `2 * heartbeat`. Verified **failing** before the watchdog, **passing** after.
- `testZeroHeartbeatDisablesWatchdog` — silent server advertising heartbeat `0`; the connection stays open. Verified **failing** when the `heartbeat == 0` guard is removed, **passing** with it.

## Test plan

- [x] `./gradlew :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)