### PR TITLE
fix: re-enable confirm/tx mode after channel restore

### DIFF
--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
@@ -43,6 +43,14 @@ open class RobustAMQPChannel(
     private var deliveryTagOffsetBeforeRestore: ULong = 0u
     private var maxBrokerTagInCurrentEpoch: ULong = 0u
 
+    // Durable record of whether the *user* asked for confirm/tx mode, kept separate from the
+    // base `isConfirmMode`/`isTxMode` flags. Those base flags track the *current broker channel's*
+    // state and are reset by prepareForRestore() (a freshly-reopened channel is not in confirm/tx
+    // mode until we re-issue the select). These intent flags survive restores so the mode is
+    // re-established on every reconnect — never reset once the user enabled it.
+    private var confirmModeRequested = false
+    private var txModeRequested = false
+
     private var declaredQos: DeclaredQos? = null
     internal val declaredExchanges = mutableMapOf<String, DeclaredExchange>()
     internal val declaredQueues = mutableMapOf<String, DeclaredQueue>()
@@ -68,6 +76,12 @@ open class RobustAMQPChannel(
         deliveryTagOffsetBeforeRestore = deliveryTagOffset
         maxBrokerTagInCurrentEpoch = 0u
         state = ConnectionState.CLOSED
+        // The freshly-reopened broker channel is NOT in confirm/tx mode; clear the base flags so
+        // restore()'s re-issued confirmSelect()/txSelect() actually send the frame (they early-return
+        // if the flag is already set). The durable confirmModeRequested/txModeRequested intent flags
+        // are untouched, so the mode is re-established below.
+        isConfirmMode = false
+        isTxMode = false
     }
 
     @InternalAmqpApi
@@ -78,6 +92,13 @@ open class RobustAMQPChannel(
             // Bound restore so a non-replying broker can't hang every writer on the channel forever.
             withTimeout(connection.config.server.restoreTimeout) {
                 open()
+
+                // Re-establish confirm/tx mode before anything is published on the new channel.
+                // Without this, basicPublish keeps returning a deliveryTag (isConfirmMode is set
+                // again below) but the broker, no longer in confirm mode, never sends Basic.Ack —
+                // so any caller awaiting a publish confirm hangs forever.
+                if (confirmModeRequested) confirmSelect()
+                if (txModeRequested) txSelect()
 
                 declaredQos?.let { basicQos(it) }
                 if (restoreTopology) {
@@ -394,6 +415,15 @@ open class RobustAMQPChannel(
             return
         }
         super.basicReject(brokerTag, requeue)
+    }
+
+    override suspend fun confirmSelect(): AMQPResponse.Channel.Confirm.Selected {
+        // Record the user's intent durably so restore() re-enables confirm mode on every reconnect.
+        return super.confirmSelect().also { confirmModeRequested = true }
+    }
+
+    override suspend fun txSelect(): AMQPResponse.Channel.Tx.Selected {
+        return super.txSelect().also { txModeRequested = true }
     }
 
 }

--- a/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/RobustAMQPChannelTest.kt
+++ b/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/RobustAMQPChannelTest.kt
@@ -646,4 +646,30 @@ class RobustAMQPChannelTest {
         }
     }
 
+    // NEW-5: confirm mode must be re-enabled after a restore. Before the fix, restore() did not
+    // re-issue confirmSelect(), so the reopened broker channel was not in confirm mode and never
+    // sent Basic.Ack — any caller awaiting a publish confirm hung forever.
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testConfirmModeReenabledAfterRestore() = runTest {
+        withConnection { connection ->
+            val channel = connection.openChannel()
+            channel.confirmSelect()
+
+            val closeEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.closedResponses.first() }
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+            channel.closeByBreaking()
+            closeEvent.await()
+            reopenEvent.await()
+
+            // Subscribe before publishing (publishConfirmResponses is a replay=0 SharedFlow). With
+            // confirm mode correctly re-enabled the broker acks the publish; otherwise this hangs.
+            val confirm = async(start = CoroutineStart.UNDISPATCHED) { channel.publishConfirmResponses.first() }
+            channel.basicPublish("after restore".toByteArray(), "", "test-confirm-${Uuid.random()}")
+            withTimeout(5.seconds) { confirm.await() }
+
+            channel.close()
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

**NEW-5 — confirm/tx mode silently lost across a reconnect.** `RobustAMQPChannel.restore()` reopened the channel and restored QoS, topology and consumers, but never re-issued `confirmSelect()`/`txSelect()`. After a reconnect the reopened broker channel was no longer in confirm mode — yet `basicPublish` still returned a `deliveryTag` (the base `isConfirmMode` flag was stale-true) — so the broker never sent `Basic.Ack` and any caller awaiting a publish confirm hung forever. Same hazard for tx mode.

### Fix

- Track the user's intent durably in `confirmModeRequested` / `txModeRequested` (set when the user calls `confirmSelect()`/`txSelect()`, never reset by restore), kept separate from the base `isConfirmMode`/`isTxMode` flags which describe the *current* broker channel.
- `prepareForRestore()` now clears `isConfirmMode`/`isTxMode` (the freshly-reopened channel genuinely isn't in those modes).
- `restore()` re-issues `confirmSelect()`/`txSelect()` after `open()` based on the durable intent — so the frame is actually sent (the base methods early-return when the flag is already set).

Scoped to NEW-5. NEW-6 (failing in-flight confirms on reconnect) and NEW-7 (per-entity restore resilience) are intentionally left for follow-ups: NEW-7 needs a recovery-failure surface (pairs with the RecoveryListener work) since most declare/bind failures close the channel, and NEW-6 needs per-tag confirm tracking that doesn't exist yet.

## Tests

- `testConfirmModeReenabledAfterRestore` — breaks the channel to force a restore, then asserts a post-restore publish is acked within a timeout. Verified **hanging (timeout)** before the fix, **passing** after.

## Test plan

- [x] `./gradlew :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)