### PR TITLE
feat: bound channel RPCs with a configurable rpcTimeout

### DIFF
--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/AMQPException.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/AMQPException.kt
@@ -1,8 +1,22 @@
 package dev.kourier.amqp
 
 import kotlinx.io.IOException
+import kotlin.time.Duration
 
 sealed class AMQPException : IOException() {
+
+    /**
+     * A channel-level RPC (queueDeclare, basicGet, confirmSelect, …) did not receive a response
+     * within the configured `rpcTimeout`. Prevents a stalled/black-holed broker from suspending
+     * the caller forever. Not a [kotlinx.coroutines.CancellationException], so robust recovery
+     * treats it as a normal failure.
+     */
+    data class RpcTimeout(
+        val channelId: ChannelId,
+        val timeout: Duration,
+    ) : AMQPException() {
+        override val message: String get() = "RPC on channel $channelId timed out after $timeout"
+    }
 
     data object InvalidUrl : AMQPException()
 

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
@@ -98,20 +98,28 @@ open class DefaultAMQPChannel(
         if (channelClosed.isCompleted) throw channelClosed.await()
         prepareForWrite()
         val firstResponse = writeMutex.withLock { // Ensure the response is synchronized with the write operation
-            // Subscribe BEFORE writing: `channelResponses` is a SharedFlow with replay=0,
-            // so any response emitted before our subscription would be lost. `onSubscription`
-            // must be applied directly to the SharedFlow (it isn't defined for plain Flow),
-            // so attach it first and filter afterwards. The action runs only after the
-            // subscription is fully wired up.
-            //
-            // Call `connection.write` directly (not the virtual `write`) so an overridden
-            // `write` in a subclass (e.g. RobustAMQPChannel awaiting restoreCompleted) can't
-            // re-enter the mutex chain and deadlock against an in-progress restore. The
-            // pre-mutex `prepareForWrite()` hook handles any required wait state.
-            channelResponses
-                .onSubscription { connection.write(*frames) }
-                .filter { it is T || it is AMQPResponse.Channel.Closed }
-                .first()
+            // Bound the wait so a stalled / black-holed broker can't suspend the caller forever
+            // (the only other escape paths are a broker Channel.Close or external cancellation).
+            // The timeout wraps only the write + response wait, inside the mutex — not the lock
+            // acquisition — so being queued behind another RPC doesn't count against it. The
+            // pre-mutex prepareForWrite() (which on RobustAMQPChannel may await an in-progress
+            // restore, itself bounded by restoreTimeout) is likewise outside this timeout.
+            withTimeoutOrNull(connection.config.server.rpcTimeout) {
+                // Subscribe BEFORE writing: `channelResponses` is a SharedFlow with replay=0,
+                // so any response emitted before our subscription would be lost. `onSubscription`
+                // must be applied directly to the SharedFlow (it isn't defined for plain Flow),
+                // so attach it first and filter afterwards. The action runs only after the
+                // subscription is fully wired up.
+                //
+                // Call `connection.write` directly (not the virtual `write`) so an overridden
+                // `write` in a subclass (e.g. RobustAMQPChannel awaiting restoreCompleted) can't
+                // re-enter the mutex chain and deadlock against an in-progress restore. The
+                // pre-mutex `prepareForWrite()` hook handles any required wait state.
+                channelResponses
+                    .onSubscription { connection.write(*frames) }
+                    .filter { it is T || it is AMQPResponse.Channel.Closed }
+                    .first()
+            } ?: throw AMQPException.RpcTimeout(channelId = id, timeout = connection.config.server.rpcTimeout)
         }
         if (firstResponse is T) return firstResponse
         if (firstResponse is AMQPResponse.Channel.Closed) throw AMQPException.ChannelClosed(

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/AMQPConfig.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/AMQPConfig.kt
@@ -21,6 +21,7 @@ data class AMQPConfig(
         val password: String = Defaults.PASSWORD,
         val vhost: String = Defaults.VHOST,
         val timeout: Duration = Defaults.timeout,
+        val rpcTimeout: Duration = Defaults.rpcTimeout,
         val connectionName: String = Defaults.CONNECTION_NAME,
         val restoreTimeout: Duration = Defaults.restoreTimeout,
         val restoreTopology: Boolean = Defaults.RESTORE_TOPOLOGY,
@@ -37,6 +38,7 @@ data class AMQPConfig(
             const val PASSWORD: String = "guest"
             const val VHOST: String = "/"
             val timeout: Duration = 60.seconds
+            val rpcTimeout: Duration = 60.seconds
             val restoreTimeout: Duration = 15.seconds
             const val CONNECTION_NAME: String = "Kourier AMQP Client"
             const val RESTORE_TOPOLOGY: Boolean = true

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/AMQPConfigServerBuilder.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/AMQPConfigServerBuilder.kt
@@ -10,6 +10,7 @@ class AMQPConfigServerBuilder {
     var password: String = AMQPConfig.Server.Defaults.PASSWORD
     var vhost: String = AMQPConfig.Server.Defaults.VHOST
     var timeout: Duration = AMQPConfig.Server.Defaults.timeout
+    var rpcTimeout: Duration = AMQPConfig.Server.Defaults.rpcTimeout
     var connectionName: String = AMQPConfig.Server.Defaults.CONNECTION_NAME
     var restoreTimeout: Duration = AMQPConfig.Server.Defaults.restoreTimeout
     var restoreTopology: Boolean = AMQPConfig.Server.Defaults.RESTORE_TOPOLOGY
@@ -25,6 +26,7 @@ class AMQPConfigServerBuilder {
             password = password,
             vhost = vhost,
             timeout = timeout,
+            rpcTimeout = rpcTimeout,
             connectionName = connectionName,
             restoreTimeout = restoreTimeout,
             restoreTopology = restoreTopology,

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/AMQPConnectionTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/AMQPConnectionTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlin.test.*
+import kotlin.time.Duration.Companion.seconds
 
 class AMQPConnectionTest {
 
@@ -160,6 +161,35 @@ class AMQPConnectionTest {
                 // The silent server never answers Connection.Close, so a graceful close() would
                 // block on CloseOk. Drop the server socket first (tears down the client read loop)
                 // and time-box the close as a safety net.
+                fakeServer.serverJob.cancel()
+                runCatching { withTimeout(2000) { connection.close() } }
+            }
+        }
+    }
+
+    // ISSUE-3: a channel-level RPC must not hang forever when the broker stalls. The server here
+    // completes the connection handshake then goes silent; openChannel() sends Channel.Open and
+    // waits for OpenOk that never arrives, so it must throw RpcTimeout once rpcTimeout elapses.
+    @Test
+    fun testRpcTimesOutWhenBrokerStalls() = runTest {
+        withContext(Dispatchers.Default) {
+            val fakeServer = FakeServer(
+                this,
+                behavior = FakeServer.Behavior.StaySilent,
+                port = 5676,
+            )
+            fakeServer.serverReady.await()
+            val connection = createAMQPConnection(this) {
+                server {
+                    port = 5676
+                    rpcTimeout = 2.seconds
+                }
+            }
+            try {
+                assertFailsWith<AMQPException.RpcTimeout> {
+                    withTimeout(8000) { connection.openChannel() }
+                }
+            } finally {
                 fakeServer.serverJob.cancel()
                 runCatching { withTimeout(2000) { connection.close() } }
             }


### PR DESCRIPTION
## Summary

**ISSUE-3 — unbounded channel RPCs.** Every channel-level RPC (`queueDeclare`, `exchangeDeclare`, `basicQos`, `basicGet`, `confirmSelect`, channel `open`/`close`, …) goes through `writeAndWaitForResponse`, which wrote the request frame then awaited the response with `.first()` and **no timeout**. A stalled or black-holed broker suspended the caller forever — the only escape paths were a broker-initiated `Channel.Close` or external cancellation. `RobustAMQPChannel.restore()` was the *only* place with a `withTimeout`; the normal call path had none. This is the "the app just stops sending" symptom on partial network failures.

### Fix

- Add a configurable `rpcTimeout` (default 60s) to `AMQPConfig.Server` and its DSL builder.
- Add `AMQPException.RpcTimeout(channelId, timeout)` — a plain `IOException` (not a `CancellationException`), so robust recovery treats it as a normal failure and can reconnect.
- Wrap the write + response wait in `writeAndWaitForResponse` with `withTimeoutOrNull(rpcTimeout)`, throwing `RpcTimeout` on expiry.

### Placement decisions

- The timeout wraps only the write + response wait, **inside** `writeMutex` — not the lock acquisition — so an RPC merely queued behind another in-flight RPC doesn't burn its budget.
- It does **not** wrap `prepareForWrite()`, which on `RobustAMQPChannel` may legitimately await an in-progress restore (already bounded by `restoreTimeout`).
- Default 60s > `restoreTimeout` 15s, so during a restore the restore bound still fires first — restore semantics are unchanged.

Scoped to ISSUE-3. NEW-4 (full `messageListeningScope` leak — also the native-CI blocker) and NEW-8 (socket/selector leak on partial connect) are left for a dedicated lifecycle-hygiene PR; NEW-4 in particular needs careful consumer-lifecycle tests (a prior blanket-cancel attempt broke 40+ tests).

## Tests

- `testRpcTimesOutWhenBrokerStalls` — `FakeServer` completes the connection handshake then goes silent, so `openChannel()`'s `Channel.Open` never gets `OpenOk`. Verified **hanging** (surfaced as `TimeoutCancellationException`) before the fix, throwing **`RpcTimeout`** after (2s `rpcTimeout` to keep it fast).

## Test plan

- [x] `./gradlew :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)