### PR TITLE
feat: validate frame size against frameMax; O(n) body reassembly

### DIFF
--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/PartialDelivery.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/PartialDelivery.kt
@@ -4,6 +4,7 @@ import dev.kourier.amqp.AMQPMessage
 import dev.kourier.amqp.AMQPResponse
 import dev.kourier.amqp.Frame
 import dev.kourier.amqp.Properties
+import dev.kourier.amqp.ProtocolError
 import io.ktor.util.logging.*
 
 data class PartialDelivery(
@@ -14,32 +15,35 @@ data class PartialDelivery(
 
     private var header: Frame.Header? = null
     private var payload: ByteArray? = null
+    private var written: Int = 0
 
     val isComplete: Boolean
-        get() = header != null && header!!.bodySize <= (payload?.size ?: 0).toUInt()
+        get() = header != null && written.toULong() == header!!.bodySize
 
     fun setHeader(header: Frame.Header) {
         if (this.header != null) error("Header already set")
         logger.debug("Setting PartialDelivery header: $header")
         this.header = header
+        // Pre-allocate the full body once. The old approach reallocated + copied the whole payload
+        // on every body frame, i.e. O(n^2) reassembly for a message split across many frames.
+        // No artificial size cap is imposed: the body comes from a trusted broker we negotiated
+        // with, and capping it would arbitrarily limit large legitimate messages.
+        this.payload = ByteArray(header.bodySize.toInt())
     }
 
-    // NOTE: should be made throwing with validation for a more restrictive protocol implementation
     fun addBody(buffer: ByteArray) {
-        if (this.header == null) error("Header must be set before adding body")
-
-        if (payload == null) {
-            logger.debug("Setting initial PartialDelivery body payload of size ${buffer.size} bytes")
-            // Reserve capacity (not needed for ByteArray, but can preallocate)
-            payload = buffer.copyOf()
-        } else {
-            logger.debug("Appending to PartialDelivery body payload with additional size ${buffer.size} bytes")
-            val oldPayload = payload!!
-            val newPayload = ByteArray(oldPayload.size + buffer.size)
-            oldPayload.copyInto(newPayload, 0, 0, oldPayload.size)
-            buffer.copyInto(newPayload, oldPayload.size, 0, buffer.size)
-            payload = newPayload
+        val payload = this.payload ?: error("Header must be set before adding body")
+        // Reject a body that overruns the size the header declared, rather than silently growing.
+        if (written + buffer.size > payload.size) {
+            throw ProtocolError.Invalid(
+                buffer.size,
+                "Body overruns declared message size ${payload.size} (have $written, +${buffer.size})",
+                this,
+            )
         }
+        logger.debug("Appending ${buffer.size} bytes to PartialDelivery body ($written/${payload.size})")
+        buffer.copyInto(payload, written)
+        written += buffer.size
     }
 
     fun asCompletedMessage(): Triple<Frame.Method.Basic, Properties, ByteArray> {

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
@@ -29,6 +29,11 @@ open class DefaultAMQPConnection(
 
     companion object {
 
+        // Frame-size ceiling applied before the broker negotiates frameMax in Tune. Only small
+        // handshake frames (Start, Tune) arrive in that window; 1 MiB is far above any legitimate
+        // one yet still blocks an oversized-frame DoS during the handshake.
+        private const val HANDSHAKE_FRAME_MAX: Long = 1L shl 20
+
         /**
          * Connect to broker.
          *
@@ -172,7 +177,7 @@ open class DefaultAMQPConnection(
         socketSubscription = messageListeningScope.launch {
             val readChannel = this@DefaultAMQPConnection.readChannel ?: return@launch
             try {
-                FrameDecoder.decodeStreaming(readChannel) { frame ->
+                FrameDecoder.decodeStreaming(readChannel, maxFrameSize = ::maxReceivableFrameSize) { frame ->
                     // Any received frame (including heartbeats) resets the missed-heartbeat clock.
                     lastFrameReceivedAt = TimeSource.Monotonic.markNow()
                     logger.debug("Received AMQP frame: $frame")
@@ -232,6 +237,12 @@ open class DefaultAMQPConnection(
             }
         }
     }
+
+    // Max size (bytes) a single incoming frame may advertise. After Tune we use the negotiated
+    // frameMax; before it (only small handshake frames arrive), fall back to a generous bound so
+    // the size check is active from the very first frame without rejecting a legitimate Start/Tune.
+    private fun maxReceivableFrameSize(): Long =
+        frameMax.toLong().takeIf { it > 0 } ?: HANDSHAKE_FRAME_MAX
 
     private suspend fun read(frame: Frame) {
         val channel = channels[frame.channelId] as? DefaultAMQPChannel

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/FrameDecoder.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/FrameDecoder.kt
@@ -13,6 +13,9 @@ object FrameDecoder {
 
     suspend fun decodeStreaming(
         channel: ByteReadChannel,
+        // Resolved per decode attempt so it picks up the broker-negotiated frameMax after Tune
+        // (a fresh decoder is created each iteration). Bounds the size a single frame may advertise.
+        maxFrameSize: () -> Long = { Long.MAX_VALUE },
         onItem: suspend (Frame) -> Unit,
     ) {
         var buffer = Buffer()
@@ -30,7 +33,7 @@ object FrameDecoder {
                 val snapshot = buffer.readBytes()
                 val workingBuffer = Buffer().apply { write(snapshot) }
 
-                val decoder = ProtocolBinaryDecoder(workingBuffer)
+                val decoder = ProtocolBinaryDecoder(workingBuffer, maxFrameSize())
 
                 try {
                     val value = decoder.decodeSerializableValue(FrameSerializer)

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/PartialDeliveryTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/channel/PartialDeliveryTest.kt
@@ -1,0 +1,48 @@
+package dev.kourier.amqp.channel
+
+import dev.kourier.amqp.Frame
+import dev.kourier.amqp.Properties
+import dev.kourier.amqp.ProtocolError
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PartialDeliveryTest {
+
+    private fun deliver() = Frame.Method.Basic.Deliver(
+        consumerTag = "c",
+        deliveryTag = 1u,
+        redelivered = false,
+        exchange = "",
+        routingKey = "k",
+    )
+
+    private fun header(bodySize: ULong) =
+        Frame.Header(classID = 60u, weight = 0u, bodySize = bodySize, properties = Properties())
+
+    // NEW-12: a body spanning more bytes than the header declared must be rejected, not silently
+    // grown (the old addBody reallocated unboundedly).
+    @Test
+    fun testBodyOverrunIsRejected() {
+        val pd = PartialDelivery(deliver())
+        pd.setHeader(header(bodySize = 10uL))
+        assertFailsWith<ProtocolError.Invalid> { pd.addBody(ByteArray(15)) }
+    }
+
+    // Reassembly across multiple body frames yields the exact bytes and completes precisely.
+    @Test
+    fun testReassemblyAcrossFrames() {
+        val pd = PartialDelivery(deliver())
+        pd.setHeader(header(bodySize = 5uL))
+        assertFalse(pd.isComplete)
+        pd.addBody(byteArrayOf(1, 2))
+        assertFalse(pd.isComplete)
+        pd.addBody(byteArrayOf(3, 4, 5))
+        assertTrue(pd.isComplete)
+
+        val (_, _, body) = pd.asCompletedMessage()
+        assertContentEquals(byteArrayOf(1, 2, 3, 4, 5), body)
+    }
+}

--- a/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/ProtocolBinaryDecoder.kt
+++ b/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/ProtocolBinaryDecoder.kt
@@ -13,6 +13,10 @@ import kotlinx.serialization.modules.SerializersModule
 
 class ProtocolBinaryDecoder(
     val buffer: Buffer,
+    // Upper bound (bytes) for a single frame's declared payload size. FrameSerializer rejects any
+    // frame advertising a larger size before allocating, so a malicious/buggy peer can't drive an
+    // unbounded ByteArray allocation (DoS/OOM). Default is unlimited for non-frame decoding.
+    val maxFrameSize: Long = Long.MAX_VALUE,
 ) : Decoder {
 
     override val serializersModule: SerializersModule = EmptySerializersModule()

--- a/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/FrameSerializer.kt
+++ b/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/FrameSerializer.kt
@@ -64,7 +64,15 @@ object FrameSerializer : KSerializer<Frame> {
             Frame.Kind.entries.first { it.value == byte }
         }
         val channelId = decoder.decodeShort().toUShort()
-        val size = decoder.decodeInt().toULong()
+        // The wire size is an unsigned 32-bit int. Validate it BEFORE allocating/reading: an
+        // out-of-range size (a malicious 4 GiB advertisement, or a value whose high bit makes
+        // size.toInt() wrap negative) would otherwise drive a giant allocation or an undefined
+        // read. Reject anything larger than the negotiated frameMax. Throwing ProtocolError.Invalid
+        // (not Incomplete) makes the streaming decoder propagate it and close the connection.
+        val size = decoder.decodeInt().toUInt()
+        if (size.toLong() > decoder.maxFrameSize) {
+            throw ProtocolError.Invalid(size, "Frame size $size exceeds maximum ${decoder.maxFrameSize}", this)
+        }
 
         val result = when (kind) {
             Frame.Kind.METHOD -> {

--- a/amqp-core/src/commonTest/kotlin/dev/kourier/amqp/FrameTest.kt
+++ b/amqp-core/src/commonTest/kotlin/dev/kourier/amqp/FrameTest.kt
@@ -1,10 +1,15 @@
 package dev.kourier.amqp
 
 import dev.kourier.amqp.serialization.ProtocolBinary
+import dev.kourier.amqp.serialization.ProtocolBinaryDecoder
+import dev.kourier.amqp.serialization.serializers.frame.FrameSerializer
+import kotlinx.io.Buffer
+import kotlinx.io.write
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class FrameTest {
 
@@ -918,6 +923,25 @@ class FrameTest {
         val encoded = ProtocolBinary.encodeToByteArray(frame)
         val decoded = ProtocolBinary.decodeFromByteArray<Frame>(encoded)
         assertEquals(frame, decoded)
+    }
+
+    // NEW-1: a frame whose declared size exceeds maxFrameSize must be rejected BEFORE allocating,
+    // so a malicious/buggy peer advertising a giant size can't drive an unbounded allocation.
+    @Test
+    fun testFrameExceedingMaxFrameSizeIsRejected() {
+        val body = ByteArray(100) { it.toByte() }
+        val bytes = ProtocolBinary.encodeToByteArray(Frame(channelId = 1u, payload = Frame.Body(body)))
+
+        // Declared size (100) exceeds the 50-byte cap → reject (same branch a 4 GiB size hits).
+        assertFailsWith<ProtocolError.Invalid> {
+            ProtocolBinaryDecoder(Buffer().apply { write(bytes) }, maxFrameSize = 50)
+                .decodeSerializableValue(FrameSerializer)
+        }
+
+        // With a sufficient cap the same frame decodes normally.
+        val frame = ProtocolBinaryDecoder(Buffer().apply { write(bytes) }, maxFrameSize = 1000)
+            .decodeSerializableValue(FrameSerializer)
+        assertEquals(100, (frame.payload as Frame.Body).body.size)
     }
 
 }


### PR DESCRIPTION
## Summary

**NEW-1 🔴 — frame size not validated → DoS/OOM.** `FrameSerializer.deserialize` read a 32-bit `size` and immediately did `readByteArray(size.toInt())` with no bound check. A malicious/buggy peer could advertise ~4 GiB (giant allocation → OOM) or set the high bit so `size.toInt()` wrapped *negative* (undefined read).
- Read the size as `UInt` (no negative wrap) and reject it **before** allocating if it exceeds the negotiated `frameMax`, throwing `ProtocolError.Invalid` (not `Incomplete`) so the streaming decoder propagates it and closes the connection.
- `frameMax` is threaded into `ProtocolBinaryDecoder`; `FrameDecoder.decodeStreaming` resolves it through a `() -> Long` provider **per decode attempt** (so it picks up the post-`Tune` value automatically), falling back to a generous 1 MiB bound during the handshake so the check is live from the first frame.

**NEW-12 🟠 — O(n²) body reassembly + no overrun check.** `PartialDelivery` reallocated and copied the whole payload on every body frame, and never checked the body against the header's declared size (`isComplete` used `>=`).
- Pre-allocate the body once from the declared `bodySize` (O(n) reassembly), track a write offset, reject any frame that overruns the declared size, and make `isComplete` exact.
- **No artificial max message size** is imposed: the body comes from a trusted broker we negotiated with, and a cap would arbitrarily limit large legitimate messages.

## Tests (broker-free unit tests)

- `testFrameExceedingMaxFrameSizeIsRejected` (amqp-core) — a real frame whose declared size exceeds `maxFrameSize` is rejected before allocating; with a sufficient max it decodes. Verified **failing** before the check.
- `PartialDeliveryTest` (amqp-client) — overrun is rejected; reassembly across frames yields the exact bytes. Verified **failing** before the checks.

## Test plan

- [x] `./gradlew :amqp-core:jvmTest :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)