### PR TITLE
perf: O(1)-per-frame decode loop; fix Field.Bytes table codec

### DIFF
--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/FrameDecoder.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/FrameDecoder.kt
@@ -5,53 +5,59 @@ import dev.kourier.amqp.ProtocolError
 import dev.kourier.amqp.serialization.ProtocolBinaryDecoder
 import dev.kourier.amqp.serialization.serializers.frame.FrameSerializer
 import io.ktor.utils.io.*
-import io.ktor.utils.io.core.*
 import kotlinx.io.Buffer
 import kotlinx.io.EOFException
 
 object FrameDecoder {
 
+    // Fixed frame prefix on the wire: kind (1) + channelId (2) + size (4).
+    private const val FRAME_HEADER_SIZE = 7L
+
     suspend fun decodeStreaming(
         channel: ByteReadChannel,
-        // Resolved per decode attempt so it picks up the broker-negotiated frameMax after Tune
-        // (a fresh decoder is created each iteration). Bounds the size a single frame may advertise.
+        // Resolved per decode attempt so it picks up the broker-negotiated frameMax after Tune.
+        // Bounds the size a single frame may advertise.
         maxFrameSize: () -> Long = { Long.MAX_VALUE },
         onItem: suspend (Frame) -> Unit,
     ) {
-        var buffer = Buffer()
+        val buffer = Buffer()
         val temp = ByteArray(4096)
 
         while (!channel.isClosedForRead) {
             val read = channel.readAvailable(temp)
             if (read == -1) break
 
-            // Append new data to buffer
+            // Append new data to the persistent buffer.
             buffer.write(temp, 0, read)
 
-            // Keep trying to decode as long as something is parsable
+            // Decode every whole frame currently buffered. We peek the fixed-size header to learn
+            // the frame's declared length WITHOUT consuming, decide whether the full frame has
+            // arrived, and only then decode destructively from `buffer`. This avoids the previous
+            // approach, which snapshotted and re-copied the entire pending buffer on every decode
+            // attempt — O(n^2) in the number of frames packed into one read.
             while (true) {
-                val snapshot = buffer.readBytes()
-                val workingBuffer = Buffer().apply { write(snapshot) }
+                val header = buffer.peek()
+                if (!header.request(FRAME_HEADER_SIZE)) break // not enough for the header yet
+                header.skip(3) // kind (1) + channelId (2)
+                val size = header.readInt().toUInt()
 
-                val decoder = ProtocolBinaryDecoder(workingBuffer, maxFrameSize())
-
-                try {
-                    val value = decoder.decodeSerializableValue(FrameSerializer)
-                    onItem(value)
-
-                    // Remove consumed bytes
-                    val consumed = snapshot.size - decoder.buffer.size.toInt()
-                    val remaining = snapshot.copyOfRange(consumed, snapshot.size)
-
-                    buffer = Buffer().apply { write(remaining) }
-                } catch (e: Exception) {
-                    if (e is ProtocolError.Incomplete || e is EOFException) {
-                        // not enough data: restore full buffer
-                        buffer = Buffer().apply { write(snapshot) }
-                        break
-                    }
-                    throw e
+                // Reject an oversized frame as soon as the header is readable, so a peer can't make
+                // us buffer toward a giant (or never-arriving) payload. Mirrors FrameSerializer's
+                // bound; enforcing it here is what actually prevents unbounded accumulation.
+                val max = maxFrameSize()
+                if (size.toLong() > max) {
+                    throw ProtocolError.Invalid(size, "Frame size $size exceeds maximum $max", this)
                 }
+
+                // Whole frame = header (7) + payload (size) + end marker (1).
+                val frameSize = FRAME_HEADER_SIZE + size.toLong() + 1L
+                if (!buffer.request(frameSize)) break // full frame not buffered yet
+
+                // The full frame's bytes are buffered, so a well-formed frame won't underflow here.
+                // (A structurally-malformed frame can still throw, which propagates and closes the
+                // connection — same as before; the end-marker check guards that case.)
+                val value = ProtocolBinaryDecoder(buffer, max).decodeSerializableValue(FrameSerializer)
+                onItem(value)
             }
         }
         throw channel.closedCause ?: EOFException("Channel closed without completing frame decoding")

--- a/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/FrameDecoderTest.kt
+++ b/amqp-client/src/commonTest/kotlin/dev/kourier/amqp/connection/FrameDecoderTest.kt
@@ -1,0 +1,112 @@
+package dev.kourier.amqp.connection
+
+import dev.kourier.amqp.Frame
+import dev.kourier.amqp.ProtocolError
+import dev.kourier.amqp.serialization.ProtocolBinary
+import io.ktor.utils.io.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.encodeToByteArray
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class FrameDecoderTest {
+
+    private fun encode(frame: Frame): ByteArray = ProtocolBinary.encodeToByteArray(frame)
+
+    // NEW-25: multiple whole frames packed into a single read must all decode. This is the path
+    // the old code walked with an O(n^2) whole-buffer snapshot/copy per frame; now O(n) via peek/skip.
+    @Test
+    fun testDecodesMultipleFramesInOneRead() = runTest {
+        withContext(Dispatchers.Default) {
+            val bytes = encode(Frame(channelId = 1u, payload = Frame.Body("a".encodeToByteArray()))) +
+                encode(Frame(channelId = 0u, payload = Frame.Heartbeat)) +
+                encode(Frame(channelId = 2u, payload = Frame.Body("bb".encodeToByteArray())))
+
+            val received = mutableListOf<Frame>()
+            // ByteReadChannel(bytes) is closed once fully read, so decodeStreaming throws EOFException
+            // at the end — expected; we only care about the frames collected before that.
+            runCatching { FrameDecoder.decodeStreaming(ByteReadChannel(bytes)) { received.add(it) } }
+
+            assertEquals(3, received.size)
+            assertEquals("a", (received[0].payload as Frame.Body).body.decodeToString())
+            assertTrue(received[1].payload is Frame.Heartbeat)
+            assertEquals("bb", (received[2].payload as Frame.Body).body.decodeToString())
+        }
+    }
+
+    // NEW-25: a frame split across reads (part of it arrives, then the rest) must not yield a frame
+    // until complete, then decode exactly once. This is the correctness-critical path of the rewrite
+    // (the peek/request "wait for more" branch).
+    @Test
+    fun testDecodesFrameSplitAcrossReads() = runTest {
+        withContext(Dispatchers.Default) {
+            val frame = encode(Frame(channelId = 1u, payload = Frame.Body("hello world".encodeToByteArray())))
+            val channel = ByteChannel(autoFlush = true)
+            val received = mutableListOf<Frame>()
+            val job = launch { runCatching { FrameDecoder.decodeStreaming(channel) { received.add(it) } } }
+
+            // First chunk: only part of the frame (mid-payload). Must not yield anything yet.
+            channel.writeByteArray(frame.copyOfRange(0, 5))
+            channel.flush()
+            delay(100)
+            assertEquals(0, received.size, "a partial frame must not produce a delivery")
+
+            // Remaining bytes complete the frame.
+            channel.writeByteArray(frame.copyOfRange(5, frame.size))
+            channel.flush()
+            withTimeout(5000) { while (received.isEmpty()) delay(10) }
+
+            channel.flushAndClose()
+            withTimeout(5000) { job.join() }
+
+            assertEquals(1, received.size)
+            assertEquals("hello world", (received[0].payload as Frame.Body).body.decodeToString())
+        }
+    }
+
+    // NEW-25: a frame split before its 7-byte header is complete (fewer than 7 bytes in the first
+    // read) must not yield anything until the header — and then the rest — arrives.
+    @Test
+    fun testDecodesFrameSplitMidHeader() = runTest {
+        withContext(Dispatchers.Default) {
+            val frame = encode(Frame(channelId = 7u, payload = Frame.Body("hi".encodeToByteArray())))
+            val channel = ByteChannel(autoFlush = true)
+            val received = mutableListOf<Frame>()
+            val job = launch { runCatching { FrameDecoder.decodeStreaming(channel) { received.add(it) } } }
+
+            channel.writeByteArray(frame.copyOfRange(0, 3)) // fewer than the 7-byte header
+            channel.flush()
+            delay(100)
+            assertEquals(0, received.size, "a partial header must not produce a delivery")
+
+            channel.writeByteArray(frame.copyOfRange(3, frame.size))
+            channel.flush()
+            withTimeout(5000) { while (received.isEmpty()) delay(10) }
+
+            channel.flushAndClose()
+            withTimeout(5000) { job.join() }
+
+            assertEquals(1, received.size)
+            assertEquals("hi", (received[0].payload as Frame.Body).body.decodeToString())
+        }
+    }
+
+    // NEW-25 / NEW-1: a frame advertising a size larger than maxFrameSize must be rejected up front
+    // (ProtocolError.Invalid) rather than buffered toward, so the connection closes instead of OOMing.
+    @Test
+    fun testRejectsOversizedFrame() = runTest {
+        withContext(Dispatchers.Default) {
+            val frame = encode(Frame(channelId = 1u, payload = Frame.Body(ByteArray(100))))
+            assertFailsWith<ProtocolError.Invalid> {
+                FrameDecoder.decodeStreaming(ByteReadChannel(frame), maxFrameSize = { 50L }) { }
+            }
+        }
+    }
+}

--- a/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/TableSerializer.kt
+++ b/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/TableSerializer.kt
@@ -6,10 +6,10 @@ import dev.kourier.amqp.Table
 import dev.kourier.amqp.serialization.ProtocolBinaryDecoder
 import dev.kourier.amqp.serialization.ProtocolBinaryEncoder
 import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.StructureKind
 import kotlinx.serialization.descriptors.buildSerialDescriptor
@@ -71,7 +71,10 @@ object TableSerializer : KSerializer<Table> {
             is Field.Float -> encoder.encodeFloat(field.value)
             is Field.Double -> encoder.encodeDouble(field.value)
             is Field.LongString -> encoder.encodeLongString(field.value)
-            is Field.Bytes -> encoder.encodeSerializableValue(ByteArraySerializer(), field.value)
+            is Field.Bytes -> {
+                encoder.encodeInt(field.value.size)
+                encoder.buffer.write(field.value)
+            }
             is Field.Array -> writeArray(field.value, encoder)
             is Field.Timestamp -> encoder.encodeLong(field.value.toEpochMilliseconds())
             is Field.Table -> encoder.encodeSerializableValue(TableSerializer, field.value)
@@ -185,9 +188,8 @@ object TableSerializer : KSerializer<Table> {
 
             Field.Kind.BYTES -> {
                 val size = decoder.decodeInt()
-                val value = ByteArray(size)
-                decoder.decodeSerializableValue(ByteArraySerializer())
-                Pair(Field.Bytes(value), 1 + size)
+                val value = decoder.buffer.readByteArray(size)
+                Pair(Field.Bytes(value), 1 + 4 + size)
             }
 
             Field.Kind.ARRAY -> {

--- a/amqp-core/src/commonTest/kotlin/dev/kourier/amqp/TableTest.kt
+++ b/amqp-core/src/commonTest/kotlin/dev/kourier/amqp/TableTest.kt
@@ -3,7 +3,9 @@ package dev.kourier.amqp
 import dev.kourier.amqp.serialization.ProtocolBinary
 import dev.kourier.amqp.serialization.serializers.TableSerializer
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class TableTest {
 
@@ -57,6 +59,51 @@ class TableTest {
     fun testTableFromTableOf() {
         val table = tableOf("boolean" to true)
         assertEquals(mapOf("boolean" to Field.Boolean(true)), table)
+    }
+
+    // NEW-26: Field.Bytes used to decode to an all-zero array (the decoded bytes were discarded),
+    // and encode hit the unsupported beginStructure. Both sides now use a 4-byte length + raw bytes,
+    // so a Field.Bytes value round-trips intact.
+    @Test
+    fun testTableBytesFieldRoundTrip() {
+        val payload = byteArrayOf(1, 2, 3, 4, 5)
+        val table: Table = mapOf("payload" to Field.Bytes(payload))
+
+        val encoded = ProtocolBinary.encodeToByteArray(TableSerializer, table)
+        val decoded = ProtocolBinary.decodeFromByteArray(TableSerializer, encoded)
+
+        val field = decoded["payload"]
+        assertTrue(field is Field.Bytes)
+        assertContentEquals(payload, field.value)
+    }
+
+    // NEW-26: empty byte array round-trips (size == 0 edge).
+    @Test
+    fun testTableEmptyBytesFieldRoundTrip() {
+        val table: Table = mapOf("empty" to Field.Bytes(byteArrayOf()))
+
+        val encoded = ProtocolBinary.encodeToByteArray(TableSerializer, table)
+        val decoded = ProtocolBinary.decodeFromByteArray(TableSerializer, encoded)
+
+        val field = decoded["empty"]
+        assertTrue(field is Field.Bytes)
+        assertContentEquals(byteArrayOf(), field.value)
+    }
+
+    // NEW-26: a Field.Bytes followed by another field verifies the decode's bytesRead accounting
+    // stays aligned — a wrong byte count would misparse the trailing field.
+    @Test
+    fun testTableBytesFieldKeepsTrailingFieldAligned() {
+        val table: Table = mapOf(
+            "payload" to Field.Bytes(byteArrayOf(9, 8, 7)),
+            "after" to Field.Int(42),
+        )
+
+        val encoded = ProtocolBinary.encodeToByteArray(TableSerializer, table)
+        val decoded = ProtocolBinary.decodeFromByteArray(TableSerializer, encoded)
+
+        assertContentEquals(byteArrayOf(9, 8, 7), (decoded["payload"] as Field.Bytes).value)
+        assertEquals(Field.Int(42), decoded["after"])
     }
 
 }


### PR DESCRIPTION
## Summary

**NEW-25 — `FrameDecoder.decodeStreaming` was O(n²).** On every decode attempt it snapshotted the *entire* pending buffer (`readBytes()`), copied it into a fresh working `Buffer`, decoded one frame, then copied the remaining bytes into another new `Buffer` (and restored the whole snapshot on incomplete data) — ~3 `Buffer` + 2 `ByteArray` allocations per frame, quadratic in frames-per-read, on the steady-state inbound hot path.

Rewritten to: keep one persistent `Buffer`; `peek()` the fixed 7-byte header (kind+channel+size) without consuming; validate `size` against `maxFrameSize`; and only when `request(8 + size)` confirms the whole frame is buffered, decode destructively from the real buffer. No whole-buffer copies — each frame is O(frame size). Oversized frames are rejected *before* requesting, so a peer can't make us buffer toward a giant payload. Uses only multiplatform kotlinx-io APIs (`peek`/`request`/`skip`); **compiles on Kotlin/Native** (macosArm64 verified).

**NEW-26 — AMQP `'x'` (byte-array) table field was broken both ways.** Encode routed through `ByteArraySerializer` → the encoder's unsupported `beginStructure` (threw); decode allocated `ByteArray(size)` but discarded the decoded bytes (always zeros) and mis-counted `bytesRead`. Both sides now use the spec format — 4-byte big-endian length + raw bytes, tag `'x'` = 120 — so a `Field.Bytes` value round-trips intact and table parsing stays aligned.

## Review

A correctness review of the diff confirmed the byte math (`8 + size`), `peek`/`request`/`skip` semantics, edge cases, and `Field.Bytes` symmetry. Two findings it raised are **pre-existing, not introduced here**, and filed as follow-ups (NEW-29: assert Method/Header consumed == declared size; NEW-30: `frameMax` total-vs-payload off-by-8). The review's suggested extra tests were added below.

## Tests (broker-free)

- `FrameDecoderTest`: multiple frames in one read; frame split mid-payload; frame split mid-header; oversized-frame rejection (`ProtocolError.Invalid`).
- `TableTest`: `Field.Bytes` round-trip (verified red→green), empty byte array, and alignment with a trailing field.
- NEW-25 decoder tests are correctness **guards** (the old code was correct-but-slow, so the perf win isn't unit-assertable); NEW-26 is a genuine red→green correctness fix.

## Test plan

- [x] `./gradlew :amqp-core:jvmTest :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)
- [x] `./gradlew compileKotlinMacosArm64 compileTestKotlinMacosArm64` (native compiles)