### PR TITLE
fix: enforce frame payload size; treat frameMax as total frame size

### DIFF
--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
@@ -18,6 +18,10 @@ open class DefaultAMQPChannel(
     override val id: ChannelId,
     val frameMax: UInt,
 ) : AMQPChannel {
+    companion object {
+        // AMQP framing overhead per frame: 7-byte header (type + channel + size) + 1-byte end marker.
+        private const val FRAME_OVERHEAD = 8
+    }
 
     protected val logger = KtorSimpleLogger("AMQPChannel")
 
@@ -223,13 +227,17 @@ open class DefaultAMQPChannel(
         val payloads = mutableListOf<Frame.Payload>()
         payloads.add(publish)
         payloads.add(header)
+        // Each body frame's total wire size is its payload plus 8 bytes of framing (7-byte header +
+        // 1-byte end marker) and must not exceed the negotiated frameMax — so the max body payload
+        // per frame is frameMax - 8.
+        val maxBodyPayload = frameMax.toInt() - FRAME_OVERHEAD
         when {
             body.isEmpty() -> {} // Do not send body
-            body.size <= frameMax.toInt() -> payloads.add(Frame.Body(body)) // Send all at once
+            body.size <= maxBodyPayload -> payloads.add(Frame.Body(body)) // Send all at once
             else -> { // Split body into multiple frames
                 var offset = 0
                 while (offset < body.size) {
-                    val length = minOf(frameMax.toInt(), body.size - offset)
+                    val length = minOf(maxBodyPayload, body.size - offset)
                     val slice = body.copyOfRange(offset, offset + length)
                     payloads.add(Frame.Body(slice))
                     offset += length

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
@@ -34,6 +34,9 @@ open class DefaultAMQPConnection(
         // one yet still blocks an oversized-frame DoS during the handshake.
         private const val HANDSHAKE_FRAME_MAX: Long = 1L shl 20
 
+        // AMQP framing overhead per frame: 7-byte header (type + channel + size) + 1-byte end marker.
+        private const val FRAME_OVERHEAD: Long = 8
+
         /**
          * Connect to broker.
          *
@@ -238,11 +241,13 @@ open class DefaultAMQPConnection(
         }
     }
 
-    // Max size (bytes) a single incoming frame may advertise. After Tune we use the negotiated
-    // frameMax; before it (only small handshake frames arrive), fall back to a generous bound so
-    // the size check is active from the very first frame without rejecting a legitimate Start/Tune.
+    // Max payload size (bytes) a single incoming frame may advertise. AMQP's negotiated frameMax is
+    // the *total* frame size, so the payload bound is frameMax minus the 8-byte framing overhead
+    // (7-byte header + 1-byte end marker). After Tune we use the negotiated frameMax; before it
+    // (only small handshake frames arrive), fall back to a generous bound so the size check is
+    // active from the very first frame without rejecting a legitimate Start/Tune.
     private fun maxReceivableFrameSize(): Long =
-        frameMax.toLong().takeIf { it > 0 } ?: HANDSHAKE_FRAME_MAX
+        (frameMax.toLong().takeIf { it > 0 } ?: HANDSHAKE_FRAME_MAX) - FRAME_OVERHEAD
 
     private suspend fun read(frame: Frame) {
         val channel = channels[frame.channelId] as? DefaultAMQPChannel

--- a/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/FrameSerializer.kt
+++ b/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/FrameSerializer.kt
@@ -74,6 +74,12 @@ object FrameSerializer : KSerializer<Frame> {
             throw ProtocolError.Invalid(size, "Frame size $size exceeds maximum ${decoder.maxFrameSize}", this)
         }
 
+        // Method/Header frames decode *structurally*, not by raw byte count, so a `size` that
+        // disagrees with the real payload length would otherwise leave the stream desynced (and the
+        // end-marker check at a shifted offset). Measure what the payload decode actually consumed
+        // and require it to equal the declared size. (BODY consumes exactly `size` by construction;
+        // HEARTBEAT consumes 0, so this also enforces a 0-size heartbeat.)
+        val remainingBefore = decoder.buffer.size
         val result = when (kind) {
             Frame.Kind.METHOD -> {
                 val payload = decoder.decodeSerializableValue(FrameMethodSerializer)
@@ -91,6 +97,10 @@ object FrameSerializer : KSerializer<Frame> {
             }
 
             Frame.Kind.HEARTBEAT -> Frame(channelId, Frame.Heartbeat)
+        }
+        val consumed = remainingBefore - decoder.buffer.size
+        if (consumed != size.toLong()) {
+            throw ProtocolError.Invalid(size, "Frame payload consumed $consumed bytes but declared size is $size", this)
         }
 
         val endMarker = decoder.decodeByte().toUByte()

--- a/amqp-core/src/commonTest/kotlin/dev/kourier/amqp/FrameTest.kt
+++ b/amqp-core/src/commonTest/kotlin/dev/kourier/amqp/FrameTest.kt
@@ -944,4 +944,24 @@ class FrameTest {
         assertEquals(100, (frame.payload as Frame.Body).body.size)
     }
 
+    // NEW-29: a Method/Header frame whose declared size overstates its real payload must be rejected
+    // (ProtocolError.Invalid), not silently accepted with the stream left desynced.
+    @Test
+    fun testMethodFrameWithOverstatedSizeIsRejected() {
+        val bytes = ProtocolBinary.encodeToByteArray(Frame(channelId = 1u, payload = Frame.Method.Basic.QosOk))
+
+        // The 4-byte big-endian size is at indices 3..6. QosOk's real payload is small (4 bytes:
+        // classId + methodId), so bumping the low byte makes the declared size overstate it.
+        val tampered = bytes.copyOf()
+        tampered[6] = (tampered[6] + 4).toByte()
+
+        assertFailsWith<ProtocolError.Invalid> {
+            ProtocolBinaryDecoder(Buffer().apply { write(tampered) })
+                .decodeSerializableValue(FrameSerializer)
+        }
+
+        // Sanity: the untampered frame still decodes fine.
+        ProtocolBinaryDecoder(Buffer().apply { write(bytes) }).decodeSerializableValue(FrameSerializer)
+    }
+
 }


### PR DESCRIPTION
## Summary

**NEW-29 — desync on a mismatched frame `size`.** `FrameSerializer` decodes Method/Header frames *structurally*, not by raw byte count, and never checked that the payload consumed exactly the declared `size` before reading the end marker. A peer sending a `size` that disagrees with the real payload length would desync the stream — the end-marker check lands at a shifted offset, and if that stray byte happens to be `0xCE` the frame is accepted with every subsequent frame corrupted. The decoder now measures bytes consumed by the payload decode and throws `ProtocolError.Invalid` if it ≠ `size`. (`BODY` consumes exactly `size` by construction; `HEARTBEAT` consumes 0, so this also enforces a 0-size heartbeat.)

**NEW-30 — `frameMax` off by 8.** AMQP's negotiated `frameMax` is the *total* frame size (payload + 8 bytes of framing: 7-byte header + 1-byte end marker), but the code compared it against the payload `size` and chunked outgoing bodies to `frameMax` — so it could emit frames up to 8 bytes over the limit and accept inbound payloads of `frameMax` (total `frameMax + 8`). Now the payload is bounded to `frameMax - 8` on both receive (`maxReceivableFrameSize`) and send (body chunking).

Both were surfaced by the PR #64 review and are pre-existing (not introduced there).

## Tests

- `testMethodFrameWithOverstatedSizeIsRejected` — a tampered Method frame whose declared `size` overstates its payload is rejected with `ProtocolError.Invalid`. Verified **red→green**.
- NEW-30 is covered by the existing `testBasicPublishFrameMaxExact` / `testBasicPublishFrameMaxMinusOne` round-trip tests (publish bodies at the `frameMax` boundary; still round-trip after the change).

## Test plan

- [x] `./gradlew :amqp-core:jvmTest :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)
- [x] `./gradlew compileKotlinMacosArm64 compileTestKotlinMacosArm64` (native compiles)