### PR TITLE
fix: make robust channel restore idempotent per broker close

### DIFF
--- a/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
+++ b/amqp-client-robust/src/commonMain/kotlin/dev/kourier/amqp/robust/RobustAMQPChannel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
+import kotlin.concurrent.Volatile
 
 open class RobustAMQPChannel(
     override val connection: RobustAMQPConnection,
@@ -32,6 +33,20 @@ open class RobustAMQPChannel(
     // any concurrent caller skips silently — the channel state ends up correctly restored
     // by the winning path.
     private val restoreLatch = Mutex()
+
+    // One-shot restore token. Armed exactly once per broker Channel.Close in onBrokerClose() —
+    // which the read loop calls BEFORE the close is observable to either restore trigger — and
+    // consumed by the first cancelAll under restoreLatch. This makes restore idempotent *per close
+    // event*: restoreLatch.tryLock alone only dedups triggers that overlap in time, but the two
+    // triggers (read-loop launch + in-flight RPC's `.also { cancelAll }`) can also run sequentially,
+    // and a second restore would re-send Channel.Open → broker 504 "second 'channel.open' seen"
+    // → connection teardown (NEW-31).
+    @Volatile
+    private var pendingRestore = false
+
+    override fun onBrokerClose() {
+        pendingRestore = true
+    }
 
     // Adjusted delivery tag tracking (similar to Java client's RecoveryAwareChannelN):
     // Each restore increments deliveryTagOffset by the highest broker tag seen in that epoch,
@@ -179,6 +194,12 @@ open class RobustAMQPChannel(
         // skip; the in-progress restore will complete the state transition for us.
         if (!restoreLatch.tryLock()) return
         try {
+            // Consume the one-shot token armed by onBrokerClose(). The first trigger to win the
+            // latch restores; any later trigger for the SAME close — whether it raced concurrently
+            // (and lost the tryLock) or arrives sequentially after this restore already finished —
+            // finds the token cleared and skips, so we never send a duplicate Channel.Open. (NEW-31)
+            if (!pendingRestore) return
+            pendingRestore = false
             logger.debug("Channel $id closed, attempting to restore...")
             restore()
         } finally {

--- a/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/RobustAMQPChannelTest.kt
+++ b/amqp-client-robust/src/commonTest/kotlin/dev/kourier/amqp/robust/RobustAMQPChannelTest.kt
@@ -672,4 +672,38 @@ class RobustAMQPChannelTest {
         }
     }
 
+    // NEW-31: one broker Channel.Close fires two restore triggers (the read-loop launch and the
+    // in-flight RPC's `.also { cancelAll }`). restoreLatch dedups them only while they OVERLAP; if
+    // the first finishes the restore before the second starts, the second used to re-send
+    // Channel.Open → broker 504 "second 'channel.open' seen" → connection teardown. Here we force
+    // that sequential case deterministically: break the channel, wait for the real restore to
+    // finish, then fire a SECOND restore trigger by hand. With the fix the one-shot token has
+    // already been consumed, so it's a no-op and the channel stays healthy.
+    @Test
+    @OptIn(DelicateCoroutinesApi::class)
+    fun testSequentialDuplicateRestoreTriggerIsNoOp() = runTest {
+        withConnection({ server { restoreTimeout = 2.seconds; rpcTimeout = 2.seconds } }) { connection ->
+            val channel = connection.openChannel() as RobustAMQPChannel
+            val reopenEvent = async(start = CoroutineStart.UNDISPATCHED) { channel.openedResponses.first() }
+
+            channel.closeByBreaking()
+            reopenEvent.await() // the single real restore has reopened the channel
+
+            // Duplicate restore trigger for the SAME close, arriving after restore already completed.
+            channel.cancelAll(
+                AMQPException.ChannelClosed(
+                    replyCode = 406u,
+                    replyText = "duplicate",
+                    isInitiatedByApplication = false,
+                )
+            )
+
+            // With the bug this sent a second Channel.Open and the broker tore down the connection;
+            // with the fix the channel is untouched, so a normal operation still succeeds.
+            val queue = "test-new31-${Uuid.random()}"
+            channel.queueDeclare(queue, durable = false, exclusive = true, autoDelete = true, arguments = emptyMap())
+            channel.close()
+        }
+    }
+
 }

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/channel/DefaultAMQPChannel.kt
@@ -140,6 +140,15 @@ open class DefaultAMQPChannel(
     @InternalAmqpApi
     open fun shouldRemoveOnBrokerClose(): Boolean = true
 
+    /**
+     * Called by the connection read loop when the broker closes this channel, *before* the
+     * `Channel.Closed` event is emitted — so the hook runs before either restore trigger can
+     * observe the close. Base channels don't restore, so this is a no-op; `RobustAMQPChannel`
+     * overrides it to arm a one-shot restore token (see its `cancelAll`).
+     */
+    @InternalAmqpApi
+    open fun onBrokerClose() {}
+
     open suspend fun cancelAll(channelClosed: AMQPException.ChannelClosed) {
         if (state == ConnectionState.CLOSED) return // Already closed
         // Complete the channelClosed deferred BEFORE flipping state to CLOSED. Reason: the

--- a/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
+++ b/amqp-client/src/commonMain/kotlin/dev/kourier/amqp/connection/DefaultAMQPConnection.kt
@@ -373,6 +373,10 @@ open class DefaultAMQPConnection(
                         replyText = payload.replyText,
                         isInitiatedByApplication = false
                     )
+                    // Arm restore BEFORE the Channel.Closed is observable, so exactly one restore
+                    // runs per broker close — consumed by the first of the two restore triggers
+                    // (this launch + the in-flight RPC's `.also { cancelAll }`). See NEW-31.
+                    channel.onBrokerClose()
                     channel.channelResponses.emit(
                         AMQPResponse.Channel.Closed(
                             channelId = frame.channelId,


### PR DESCRIPTION
## Summary

**NEW-31 — "second 'channel.open' seen" double-restore race** (the NEW-23 fix was incomplete).

A single broker `Channel.Close` fires **two** restore triggers: the read loop's `brokerCloseRestoresScope.launch { cancelAll }` and the in-flight RPC's `.also { cancelAll(it) }` in `writeAndWaitForResponse`. NEW-23's `restoreLatch.tryLock` only dedups them while they **overlap in time**. When the broker answers the first restore's `Channel.Open` fast enough that the first `cancelAll` completes the whole restore and releases the latch *before* the second trigger starts, the second sails through every guard (state is now OPEN, latch is free) and re-sends `Channel.Open` → broker replies `Connection.Close(504 CHANNEL_ERROR - "second 'channel.open' seen")` → the **whole connection is torn down**.

Timing-dependent, so it flakes under load — it surfaced on the **v0.4.5 release CI build** (RabbitMQ 4.1.8) in `testDeleteQueue`. Self-healing (the robust layer reconnects), but disruptive.

### Fix — a one-shot restore token (idempotent per close event)

- `DefaultAMQPChannel` gains an open `onBrokerClose()` hook (no-op).
- The read loop calls `channel.onBrokerClose()` **before** emitting `Channel.Closed`, so it runs before either trigger can observe the close.
- `RobustAMQPChannel` arms a `@Volatile pendingRestore` flag there and **consumes** it in `cancelAll` under `restoreLatch` (`if (!pendingRestore) return; pendingRestore = false`) before restoring. The first trigger to win the latch restores; any later trigger for the same close — concurrent **or sequential** — finds the token cleared and skips. Re-armed on the next close.

## Tests

- `testSequentialDuplicateRestoreTriggerIsNoOp` forces the sequential case deterministically: break the channel, await the real restore, then fire a second `cancelAll` by hand. Verified **failing** (`ChannelClosed 504`) before the fix, **passing** after.
- The timing flake itself is not locally reproducible (25/25 passes under 10 CPU burners), which is why the test forces the sequential ordering directly.

## Test plan

- [x] `./gradlew :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)
- [x] `./gradlew compileKotlinMacosArm64 compileTestKotlinMacosArm64` (native compiles)