### PR TITLE
perf: precompute codec enum lookups; move (not copy) length-prefixed payloads

### DIFF
--- a/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/TableSerializer.kt
+++ b/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/TableSerializer.kt
@@ -19,6 +19,10 @@ import kotlin.time.Instant
 
 object TableSerializer : KSerializer<Table> {
 
+    // Precomputed value -> Field.Kind lookup (NEW-28): avoids a linear scan + lambda allocation
+    // per table field decoded. getValue() preserves the old `entries.first { }` failure behavior.
+    private val fieldKindByValue = Field.Kind.entries.associateBy { it.value }
+
     @OptIn(InternalSerializationApi::class)
     override val descriptor: SerialDescriptor
         get() = buildSerialDescriptor("Table", StructureKind.OBJECT)
@@ -40,7 +44,7 @@ object TableSerializer : KSerializer<Table> {
             }
         }
         encoder.encodeInt(innerEncoder.buffer.size.toInt())
-        innerEncoder.buffer.copyTo(encoder.buffer)
+        encoder.buffer.transferFrom(innerEncoder.buffer)
     }
 
     fun writeArray(values: List<Field>, encoder: ProtocolBinaryEncoder) {
@@ -53,7 +57,7 @@ object TableSerializer : KSerializer<Table> {
             }
         }
         encoder.encodeInt(innerEncoder.buffer.size.toInt())
-        innerEncoder.buffer.copyTo(encoder.buffer)
+        encoder.buffer.transferFrom(innerEncoder.buffer)
     }
 
     @OptIn(ExperimentalSerializationApi::class)
@@ -127,9 +131,7 @@ object TableSerializer : KSerializer<Table> {
     }
 
     private fun readField(decoder: ProtocolBinaryDecoder): Pair<Field, Int> {
-        val kind = decoder.decodeByte().toUByte().let { byte ->
-            Field.Kind.entries.first { it.value == byte }
-        }
+        val kind = fieldKindByValue.getValue(decoder.decodeByte().toUByte())
         return when (kind) {
             Field.Kind.BOOLEAN -> {
                 val value = decoder.decodeBoolean()

--- a/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/FrameSerializer.kt
+++ b/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/FrameSerializer.kt
@@ -17,6 +17,11 @@ import kotlinx.serialization.encoding.Encoder
 
 object FrameSerializer : KSerializer<Frame> {
 
+    // Precomputed value -> Kind lookup, so decoding a frame doesn't do a linear scan + lambda
+    // allocation per frame on the inbound hot path (NEW-28). getValue() throws the same
+    // NoSuchElementException the old `entries.first { }` did on an unknown kind.
+    private val kindByValue = Frame.Kind.entries.associateBy { it.value }
+
     @OptIn(InternalSerializationApi::class)
     override val descriptor: SerialDescriptor
         get() = buildSerialDescriptor("Frame", StructureKind.OBJECT)
@@ -32,14 +37,14 @@ object FrameSerializer : KSerializer<Frame> {
                 val innerEncoder = ProtocolBinaryEncoder(Buffer())
                 innerEncoder.encodeSerializableValue(FrameMethodSerializer, payload)
                 encoder.encodeInt(innerEncoder.buffer.size.toInt())
-                innerEncoder.buffer.copyTo(encoder.buffer)
+                encoder.buffer.transferFrom(innerEncoder.buffer)
             }
 
             is Frame.Header -> {
                 val innerEncoder = ProtocolBinaryEncoder(Buffer())
                 innerEncoder.encodeSerializableValue(FrameHeaderSerializer, payload)
                 encoder.encodeInt(innerEncoder.buffer.size.toInt())
-                innerEncoder.buffer.copyTo(encoder.buffer)
+                encoder.buffer.transferFrom(innerEncoder.buffer)
             }
 
             is Frame.Body -> {
@@ -60,9 +65,7 @@ object FrameSerializer : KSerializer<Frame> {
     override fun deserialize(decoder: Decoder): Frame {
         require(decoder is ProtocolBinaryDecoder)
 
-        val kind = decoder.decodeByte().toUByte().let { byte ->
-            Frame.Kind.entries.first { it.value == byte }
-        }
+        val kind = kindByValue.getValue(decoder.decodeByte().toUByte())
         val channelId = decoder.decodeShort().toUShort()
         // The wire size is an unsigned 32-bit int. Validate it BEFORE allocating/reading: an
         // out-of-range size (a malicious 4 GiB advertisement, or a value whose high bit makes

--- a/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/method/FrameMethodSerializer.kt
+++ b/amqp-core/src/commonMain/kotlin/dev/kourier/amqp/serialization/serializers/frame/method/FrameMethodSerializer.kt
@@ -18,6 +18,10 @@ import kotlinx.serialization.encoding.Encoder
 
 object FrameMethodSerializer : KSerializer<Frame.Method> {
 
+    // Precomputed value -> Kind lookup (NEW-28): avoids a linear scan + lambda allocation per
+    // method frame decoded. getValue() preserves the old `entries.first { }` failure behavior.
+    private val kindByValue = Frame.Method.Kind.entries.associateBy { it.value }
+
     @OptIn(InternalSerializationApi::class)
     override val descriptor: SerialDescriptor
         get() = buildSerialDescriptor("Frame.Method", StructureKind.OBJECT)
@@ -36,9 +40,7 @@ object FrameMethodSerializer : KSerializer<Frame.Method> {
     }
 
     override fun deserialize(decoder: Decoder): Frame.Method {
-        val kind = decoder.decodeShort().toUShort().let { byte ->
-            Frame.Method.Kind.entries.first { it.value == byte }
-        }
+        val kind = kindByValue.getValue(decoder.decodeShort().toUShort())
         return when (kind) {
             Frame.Method.Kind.CONNECTION -> decoder.decodeSerializableValue(FrameMethodConnectionSerializer)
             Frame.Method.Kind.CHANNEL -> decoder.decodeSerializableValue(FrameMethodChannelSerializer)


### PR DESCRIPTION
## Summary

Two behavior-preserving serialization micro-opts (no wire-format change).

**NEW-28 — per-frame/per-field enum lookup.** Decoding did `Kind.entries.first { it.value == byte }` — a linear scan plus a lambda allocation on every frame and every table field, on the inbound hot path. Replaced with a precomputed `value -> Kind` map in `FrameSerializer`, `FrameMethodSerializer`, and `TableSerializer`, looked up via `getValue()` (which keeps the same `NoSuchElementException`-on-unknown-kind behavior).

**NEW-27 — length-prefix copy.** Method/Header frames and table/array bodies are encoded into a throwaway inner `Buffer` to measure their length, then were appended to the outer buffer with `copyTo` (a full byte copy — recursive for nested tables). Switched to `transferFrom`, which moves the inner buffer's segments into the outer one with no byte copy; the inner buffer is discarded either way.

Both surfaced in the 2026-05-23 serialization review.

## Tests

Behavior-preserving, so the guards are the existing round-trip tests:
- amqp-core `FrameTest` / `TableTest` (pure encode→decode equality) — green, confirming the wire format is byte-identical.
- Full `:amqp-client` + `:amqp-client-robust` integration suite — green.

## Test plan

- [x] `./gradlew :amqp-core:jvmTest :amqp-client:jvmTest :amqp-client-robust:jvmTest` (green)
- [x] `./gradlew compileKotlinMacosArm64` (native compiles)